### PR TITLE
release: 1.0.0-beta.2 を develop へ戻す

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.2] - 2026-08-05
+
 ### Added
 
 - Admin API: complete coverage of all 99 `/api/admin/*` endpoints
@@ -99,4 +101,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `i/2fa/update-key` name parameter changed to optional
 
+[1.0.0-beta.2]: https://github.com/LibraryLibrarian/misskey_client/releases/tag/v1.0.0-beta.2
 [1.0.0-beta.1]: https://github.com/LibraryLibrarian/misskey_client/releases/tag/v1.0.0-beta.1

--- a/README.de.md
+++ b/README.de.md
@@ -22,7 +22,7 @@ Fügen Sie das Paket zu Ihrer `pubspec.yaml` hinzu:
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.1
+  misskey_client: ^1.0.0-beta.2
 ```
 
 Führen Sie anschließend aus:

--- a/README.fr.md
+++ b/README.fr.md
@@ -22,7 +22,7 @@ Ajoutez le package à votre `pubspec.yaml` :
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.1
+  misskey_client: ^1.0.0-beta.2
 ```
 
 Puis exécutez :

--- a/README.ja.md
+++ b/README.ja.md
@@ -21,7 +21,7 @@
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.1
+  misskey_client: ^1.0.0-beta.2
 ```
 
 その後、以下を実行します：

--- a/README.ko.md
+++ b/README.ko.md
@@ -22,7 +22,7 @@
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.1
+  misskey_client: ^1.0.0-beta.2
 ```
 
 그런 다음 실행합니다:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add the package to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.1
+  misskey_client: ^1.0.0-beta.2
 ```
 
 Then run:

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -22,7 +22,7 @@
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.1
+  misskey_client: ^1.0.0-beta.2
 ```
 
 然后运行：

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -23,7 +23,7 @@ Add the dependency to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.1
+  misskey_client: ^1.0.0-beta.2
 ```
 
 Then fetch it:

--- a/docs/i18n/de/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/de/docusaurus-plugin-content-docs/current/getting-started.md
@@ -23,7 +23,7 @@ Fuegen Sie die Abhaengigkeit in Ihre `pubspec.yaml` ein:
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.1
+  misskey_client: ^1.0.0-beta.2
 ```
 
 Anschliessend laden Sie das Paket herunter:

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/getting-started.md
@@ -23,7 +23,7 @@ Ajoutez la dépendance à votre `pubspec.yaml` :
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.1
+  misskey_client: ^1.0.0-beta.2
 ```
 
 Puis récupérez-la :

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/getting-started.md
@@ -19,7 +19,7 @@ slug: /
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.1
+  misskey_client: ^1.0.0-beta.2
 ```
 
 その後、依存関係を取得します。

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started.md
@@ -23,7 +23,7 @@ Flutter, 서버 사이드 Dart, CLI 도구 등 Dart가 실행되는 모든 환�
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.1
+  misskey_client: ^1.0.0-beta.2
 ```
 
 그 다음 패키지를 가져옵니다:

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started.md
@@ -23,7 +23,7 @@ misskey_client 是一个纯 Dart 编写的 Misskey API 客户端库。
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.1
+  misskey_client: ^1.0.0-beta.2
 ```
 
 然后获取依赖：

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: misskey_client
-version: 1.0.0-beta.1
+version: 1.0.0-beta.2
 documentation: https://librarylibrarian.github.io/misskey_client/
 environment:
   sdk: ">=3.5.0 <4.0.0"


### PR DESCRIPTION
## Summary

git-flow のリリースフローに沿った、`release/1.0.0-beta.2` の develop への戻しマージ。

develop には既に PR #13 までの内容が入っているため、このPRで develop に加わるのは `675f429 docs: 1.0.0-beta.2のバージョン対応` の1コミットのみ。

## 変更内容

- `pubspec.yaml` のバージョンを 1.0.0-beta.2 に更新
- CHANGELOG の `[Unreleased]` を `[1.0.0-beta.2] - 2026-08-05` として確定し、リンク定義を追加
- README×6 と docs×6 のインストール手順のバージョン表記を追随

## 備考

main へのマージは別PRで行う。順序は main → タグ付け → 本PR を想定している。

## Test plan

- [x] `dart analyze` — No issues found
- [x] `dart test` — 459テスト成功
- [x] `dart pub publish --dry-run` — Package has 0 warnings
