### PR TITLE
fix: MisskeyClip に notesCount を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `MisskeyClip.notesCount`: the number of notes in a clip. The server already returned this field, but the model did not declare it, so it was silently discarded on deserialization. It now surfaces on every clip-returning endpoint: `ClipsApi.create()` / `update()` / `show()` / `list()` / `myFavorites()`, `NotesApi.clips()`, and `UsersApi.clips()`. Misskey packs this field only for the clip's owner, so it stays `null` when reading another user's clip or when unauthenticated. It is deliberately left without a default value so that "not disclosed" remains distinguishable from an empty clip
+
 ## [1.0.0-beta.2] - 2026-08-05
 
 ### Added

--- a/lib/src/models/misskey_clip.dart
+++ b/lib/src/models/misskey_clip.dart
@@ -19,6 +19,7 @@ class MisskeyClip {
     this.isPublic,
     this.favoritedCount,
     this.isFavorited,
+    this.notesCount,
   });
 
   factory MisskeyClip.fromJson(Map<String, dynamic> json) =>
@@ -58,4 +59,12 @@ class MisskeyClip {
 
   /// Whether the current user has favorited this clip.
   final bool? isFavorited;
+
+  /// The number of notes in this clip.
+  ///
+  /// The server only returns this field to the clip's owner, so it is `null`
+  /// when reading another user's clip or when unauthenticated. It is
+  /// deliberately left without a default so that "not disclosed" stays
+  /// distinguishable from an empty clip.
+  final int? notesCount;
 }

--- a/lib/src/models/misskey_clip.g.dart
+++ b/lib/src/models/misskey_clip.g.dart
@@ -20,6 +20,7 @@ MisskeyClip _$MisskeyClipFromJson(Map<String, dynamic> json) => MisskeyClip(
       isPublic: json['isPublic'] as bool? ?? false,
       favoritedCount: (json['favoritedCount'] as num?)?.toInt() ?? 0,
       isFavorited: json['isFavorited'] as bool?,
+      notesCount: (json['notesCount'] as num?)?.toInt(),
     );
 
 Map<String, dynamic> _$MisskeyClipToJson(MisskeyClip instance) =>
@@ -35,4 +36,5 @@ Map<String, dynamic> _$MisskeyClipToJson(MisskeyClip instance) =>
       'isPublic': instance.isPublic,
       'favoritedCount': instance.favoritedCount,
       'isFavorited': instance.isFavorited,
+      'notesCount': instance.notesCount,
     };

--- a/test/models/misskey_clip_test.dart
+++ b/test/models/misskey_clip_test.dart
@@ -35,5 +35,24 @@ void main() {
       expect(clip.user, isNotNull);
       expect(clip.user?.username, 'testadmin');
     });
+
+    test('parses notesCount', () {
+      final file = File('test/fixtures/clips_list.json');
+      final jsonList = jsonDecode(file.readAsStringSync()) as List<dynamic>;
+      final clip = MisskeyClip.fromJson(jsonList.first as Map<String, dynamic>);
+
+      expect(clip.notesCount, 1);
+    });
+
+    test('notesCount is null when the field is absent', () {
+      final file = File('test/fixtures/clips_list.json');
+      final jsonList = jsonDecode(file.readAsStringSync()) as List<dynamic>;
+      final json = (jsonList.first as Map<String, dynamic>)
+        ..remove('notesCount');
+
+      final clip = MisskeyClip.fromJson(json);
+
+      expect(clip.notesCount, isNull);
+    });
   });
 }


### PR DESCRIPTION
## Summary

`clips/list` などのレスポンスには `notesCount` が含まれているにもかかわらず、`MisskeyClip` にフィールドが未定義だったため、デシリアライズ時に黙って破棄されていた。`json_serializable` は既定で未知のキーを無視するので例外も出ず、利用側からは値が存在しないように見える状態だった。

実APIレスポンスから採取した `test/fixtures/clips_list.json` にも `"notesCount": 1` が入っており、サーバーが返していることは確認済み。

## 変更内容

`MisskeyClip` に `int? notesCount` を追加した。`MisskeyClip` は `clips/list` 専用ではないため、以下すべてのエンドポイントで取得できるようになる。

| API | メソッド |
|---|---|
| `ClipsApi` | `create()` / `update()` / `show()` / `list()` / `myFavorites()` |
| `NotesApi` | `clips()` |
| `UsersApi` | `clips()` |

## defaultValue を設定しない理由

同じモデルの `isPublic` / `favoritedCount` は `@JsonKey(defaultValue: ...)` を持つが、`notesCount` にはあえて設定していない。

Misskey 本家の `packedClipSchema` では `notesCount` は `optional: true, nullable: false` で、`ClipEntityService.pack()` の実装は以下の通り。

```ts
notesCount: (meId === clip.userId) ? await this.clipNotesRepository.countBy({ clipId: clip.id }) : undefined,
```

つまり **閲覧者がクリップの所有者である場合にのみ** 含まれる。`defaultValue: 0` を付けると「所有者でないため非開示」と「クリップが空(0件)」が両方 `0` に潰れて区別できなくなるため、`null` のまま利用側に渡す。

`clips/list`(自分のクリップ一覧)では常に値が入るが、`users/clips` で他人のクリップを見た場合や未認証時は `null` になる。この挙動は dartdoc に明記した。

## テスト

`test/models/misskey_clip_test.dart` に2件追加。

- `parses notesCount` — fixture の値(`1`)が読めること
- `notesCount is null when the field is absent` — フィールドが欠落した場合に `null` になること。既存の `misskey_note_test.dart` の `..remove(...)` パターンに合わせている

## 確認

- `dart run build_runner build` で `.g.dart` を再生成(手動編集なし)
- `dart analyze` — No issues found
- `dart test` — 461 passed(E2E 6件は `RUN_E2E` 未設定によりスキップ)

## 破壊的変更

なし。オプショナル引数の末尾追加のみ。`misskey_client.dart` からの `MisskeyClip` の export は既存のため追加不要。

`mastodon_client` 側に clip 相当の概念は存在しないため、そちらへの影響もない。
