### PR TITLE
release: 1.0.0-beta.3 を develop へ戻す

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -1,1 +1,10 @@
 docs/
+
+# 開発支援・ローカル環境用ファイル
+/AGENTS.md
+/CLAUDE.md
+/firebase-debug.log
+/*.iml
+
+# pub.dev 側で生成される API ドキュメント
+/doc/api/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.3] - 2026-08-05
+
 ### Added
 
 - `MisskeyClip.notesCount`: the number of notes in a clip. The server already returned this field, but the model did not declare it, so it was silently discarded on deserialization. It now surfaces on every clip-returning endpoint: `ClipsApi.create()` / `update()` / `show()` / `list()` / `myFavorites()`, `NotesApi.clips()`, and `UsersApi.clips()`. Misskey packs this field only for the clip's owner, so it stays `null` when reading another user's clip or when unauthenticated. It is deliberately left without a default value so that "not disclosed" remains distinguishable from an empty clip
@@ -105,5 +107,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `i/2fa/update-key` name parameter changed to optional
 
+[1.0.0-beta.3]: https://github.com/LibraryLibrarian/misskey_client/releases/tag/v1.0.0-beta.3
 [1.0.0-beta.2]: https://github.com/LibraryLibrarian/misskey_client/releases/tag/v1.0.0-beta.2
 [1.0.0-beta.1]: https://github.com/LibraryLibrarian/misskey_client/releases/tag/v1.0.0-beta.1

--- a/README.de.md
+++ b/README.de.md
@@ -22,7 +22,7 @@ Fügen Sie das Paket zu Ihrer `pubspec.yaml` hinzu:
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.2
+  misskey_client: ^1.0.0-beta.3
 ```
 
 Führen Sie anschließend aus:

--- a/README.fr.md
+++ b/README.fr.md
@@ -22,7 +22,7 @@ Ajoutez le package à votre `pubspec.yaml` :
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.2
+  misskey_client: ^1.0.0-beta.3
 ```
 
 Puis exécutez :

--- a/README.ja.md
+++ b/README.ja.md
@@ -21,7 +21,7 @@
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.2
+  misskey_client: ^1.0.0-beta.3
 ```
 
 その後、以下を実行します：

--- a/README.ko.md
+++ b/README.ko.md
@@ -22,7 +22,7 @@
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.2
+  misskey_client: ^1.0.0-beta.3
 ```
 
 그런 다음 실행합니다:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add the package to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.2
+  misskey_client: ^1.0.0-beta.3
 ```
 
 Then run:

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -22,7 +22,7 @@
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.2
+  misskey_client: ^1.0.0-beta.3
 ```
 
 然后运行：

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -23,7 +23,7 @@ Add the dependency to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.2
+  misskey_client: ^1.0.0-beta.3
 ```
 
 Then fetch it:

--- a/docs/i18n/de/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/de/docusaurus-plugin-content-docs/current/getting-started.md
@@ -23,7 +23,7 @@ Fuegen Sie die Abhaengigkeit in Ihre `pubspec.yaml` ein:
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.2
+  misskey_client: ^1.0.0-beta.3
 ```
 
 Anschliessend laden Sie das Paket herunter:

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/getting-started.md
@@ -23,7 +23,7 @@ Ajoutez la dépendance à votre `pubspec.yaml` :
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.2
+  misskey_client: ^1.0.0-beta.3
 ```
 
 Puis récupérez-la :

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/getting-started.md
@@ -19,7 +19,7 @@ slug: /
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.2
+  misskey_client: ^1.0.0-beta.3
 ```
 
 その後、依存関係を取得します。

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started.md
@@ -23,7 +23,7 @@ Flutter, 서버 사이드 Dart, CLI 도구 등 Dart가 실행되는 모든 환�
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.2
+  misskey_client: ^1.0.0-beta.3
 ```
 
 그 다음 패키지를 가져옵니다:

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started.md
@@ -23,7 +23,7 @@ misskey_client 是一个纯 Dart 编写的 Misskey API 客户端库。
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.2
+  misskey_client: ^1.0.0-beta.3
 ```
 
 然后获取依赖：

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: misskey_client
-version: 1.0.0-beta.2
+version: 1.0.0-beta.3
 documentation: https://librarylibrarian.github.io/misskey_client/
 environment:
   sdk: ">=3.5.0 <4.0.0"


### PR DESCRIPTION
## Summary

`1.0.0-beta.3` のリリース確定内容を develop へ戻す。

main 向け PR #27 でマージ済みのリリース準備コミットを反映し、以後の開発が beta3 のバージョン表記と CHANGELOG を引き継ぐようにする。

## 反映内容

- `pubspec.yaml` を `1.0.0-beta.3` に更新
- CHANGELOG の `[Unreleased]` を `[1.0.0-beta.3]` として確定しタグリンクを追加
- README 6言語と Docusaurus 6言語のインストール例を更新
- `.pubignore` から開発専用ファイルと生成済み API ドキュメントを除外

## リリース状況

- main 向け PR #27: マージ済み
- 軽量タグ `v1.0.0-beta.3`: main のマージコミット `7c151fdb` に付与済み
- pub.dev 公開: このPRのマージ後に実施予定

## Test plan

- [x] `dart analyze` — No issues found
- [x] `dart test` — 461テスト成功、E2E 6件は環境未設定のためスキップ
- [x] `dart pub publish --dry-run` — Package has 0 warnings