### PR TITLE
fix: 公開パッケージから不要な開発ファイルを除外

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -3,8 +3,12 @@ docs/
 # 開発支援・ローカル環境用ファイル
 /AGENTS.md
 /CLAUDE.md
+/.claude/
 /firebase-debug.log
 /*.iml
+
+# テスト用ファイル
+/test/
 
 # pub.dev 側で生成される API ドキュメント
 /doc/api/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Reduced the published package size by excluding test sources and local agent configuration (issue #16)
+
 ## [1.0.0-beta.3] - 2026-08-05
 
 ### Added


### PR DESCRIPTION
## 概要

- `.pubignore` に `/.claude/` と `/test/` を追加
- 公開パッケージからローカルエージェント設定とテストソースを除外
- CHANGELOG の Unreleased に変更内容を追記

最新の `develop` では `doc/api/`、`CLAUDE.md` などの除外が既に反映されていたため、Issue #16 の残件を対応しています。

## 検証

- `.fvm/flutter_sdk/bin/dart pub publish --dry-run`
  - Package has 0 warnings
  - 圧縮後サイズ: 212 KB → 128 KB
  - 公開対象: 230ファイル
- `.fvm/flutter_sdk/bin/dart test`
  - 461件成功
  - E2E 6件は環境未設定のためスキップ

Closes #16