### PR TITLE
ci: pub.devへの自動公開ワークフローを追加

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,14 @@
+name: Publish to pub.dev
+
+on:
+  push:
+    # プレリリースを含むバージョンタグをpub.dev側のtag patternで検証する
+    tags: ['v*']
+
+jobs:
+  publish:
+    permissions:
+      id-token: write
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    with:
+      environment: pub.dev


### PR DESCRIPTION
## 概要

Issue #29 Phase 2として、pub.devへの自動公開ワークフローを追加します。

## 変更内容

- `v*`タグのpushを公開契機として設定
- `dart-lang/setup-dart`の公式reusable workflowを使用
- OIDC認証に必要な`id-token: write`を付与
- GitHub Environment `pub.dev`を指定
- プレリリースを含むタグの最終検証は、pub.dev側の`v{{version}}`パターンへ委譲

## 管理画面で別途必要な設定

- pub.devでGitHub Actionsからの自動公開を有効化
- Repositoryを`LibraryLibrarian/misskey_client`に設定
- Tag patternを`v{{version}}`に設定
- Environmentを`pub.dev`に設定
- GitHub Environment `pub.dev`を作成し、初回はRequired reviewersを設定

## 確認内容

- YAML構文チェック
- `dart format --output=none --set-exit-if-changed .`
- `dart analyze --fatal-infos`
- `dart run build_runner build`
- `dart test --exclude-tags e2e`（461件成功）
- `dart pub publish --dry-run`（警告0件）

実際のOIDC公開は管理画面設定後、次回のリリースタグで確認します。

Relates to #29
