### PR TITLE
feat: GitHub Releaseの自動生成を追加

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,3 +25,33 @@ jobs:
     uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
     with:
       environment: pub.dev
+
+  release:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dart-lang/setup-dart@v1
+
+      - name: Extract release notes
+        run: >-
+          dart run tool/release_notes.dart "${GITHUB_REF_NAME#v}"
+          > "$RUNNER_TEMP/release-notes.md"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          release_options=()
+          if [[ "${GITHUB_REF_NAME#v}" == *-* ]]; then
+            release_options+=(--prerelease --latest=false)
+          fi
+
+          gh release create "$GITHUB_REF_NAME" \
+            --verify-tag \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file "$RUNNER_TEMP/release-notes.md" \
+            "${release_options[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added CI checks for formatting, static analysis, generated code, unit tests, and package validation on the minimum and stable Dart SDKs (issue #29)
 - Added OIDC-based pub.dev publishing and release version update/verification tooling (issue #29)
+- Added automatic GitHub Release creation from the matching CHANGELOG section after a successful pub.dev publication (issue #29)
 
 ### Changed
 

--- a/test/tool/release_project_test.dart
+++ b/test/tool/release_project_test.dart
@@ -111,6 +111,38 @@ void main() {
     );
   });
 
+  test('extractReleaseNotes returns only the requested release body', () {
+    final notes = extractReleaseNotes(root, '1.0.0-beta.3');
+
+    expect(notes, '### Added\n\n- Released change\n');
+    expect(notes, isNot(contains('Pending change')));
+    expect(notes, isNot(contains('1.0.0-beta.2')));
+  });
+
+  test('extractReleaseNotes rejects a release without notes', () {
+    _write(
+      root,
+      'CHANGELOG.md',
+      '# Changelog\n\n'
+          '## [Unreleased]\n\n'
+          '## [1.0.0-beta.3] - 2026-08-05\n\n'
+          '## [1.0.0-beta.2] - 2026-07-01\n\n'
+          '### Fixed\n\n'
+          '- Older change\n',
+    );
+
+    expect(
+      () => extractReleaseNotes(root, '1.0.0-beta.3'),
+      throwsA(
+        isA<ReleaseToolException>().having(
+          (error) => error.message,
+          'message',
+          contains('no release notes'),
+        ),
+      ),
+    );
+  });
+
   test('release tools reject invalid Semantic Versions', () {
     expect(
       () => bumpVersion(root, '1.0'),
@@ -146,7 +178,12 @@ void _createProject(Directory root) {
         '## [Unreleased]\n\n'
         '### Added\n\n'
         '- Pending change\n\n'
-        '## [1.0.0-beta.3] - 2026-08-05\n',
+        '## [1.0.0-beta.3] - 2026-08-05\n\n'
+        '### Added\n\n'
+        '- Released change\n\n'
+        '## [1.0.0-beta.2] - 2026-07-01\n\n'
+        '### Fixed\n\n'
+        '- Older change\n',
   );
 }
 

--- a/tool/release_notes.dart
+++ b/tool/release_notes.dart
@@ -1,0 +1,24 @@
+import 'dart:io';
+
+import 'src/release_project.dart';
+
+void main(List<String> arguments) {
+  if (arguments.length != 1) {
+    stderr.writeln(
+      'Usage: dart run tool/release_notes.dart <version>\n'
+      'Example: dart run tool/release_notes.dart 1.0.0-beta.4',
+    );
+    exitCode = 64;
+    return;
+  }
+
+  try {
+    stdout.write(extractReleaseNotes(Directory.current, arguments.single));
+  } on ReleaseToolException catch (error) {
+    stderr.writeln('Release note extraction failed: ${error.message}');
+    exitCode = 1;
+  } on FileSystemException catch (error) {
+    stderr.writeln('Release note extraction failed: ${error.message}');
+    exitCode = 1;
+  }
+}

--- a/tool/src/release_project.dart
+++ b/tool/src/release_project.dart
@@ -106,26 +106,53 @@ void verifyRelease(Directory root, String expectedVersion) {
     );
   }
 
+  final heading = _releaseHeading(
+    _readFile(root, 'CHANGELOG.md'),
+    expectedVersion,
+  );
+  final date = heading.group(1)!;
+  if (!_isValidDate(date)) {
+    throw ReleaseToolException(
+      'CHANGELOG.md has an invalid release date for $expectedVersion: $date.',
+    );
+  }
+}
+
+/// Extracts the CHANGELOG body for [version] to use as release notes.
+String extractReleaseNotes(Directory root, String version) {
+  validateReleaseVersion(version);
+
   final changelog = _readFile(root, 'CHANGELOG.md');
+  final heading = _releaseHeading(changelog, version);
+  final nextHeading = RegExp(
+    r'^## \[[^\]]+\](?:[ \t]+-[ \t]+.*)?$',
+    multiLine: true,
+  ).firstMatch(changelog.substring(heading.end));
+  final end = nextHeading == null
+      ? changelog.length
+      : heading.end + nextHeading.start;
+  final notes = changelog.substring(heading.end, end).trim();
+  if (notes.isEmpty) {
+    throw ReleaseToolException(
+      'CHANGELOG.md has no release notes for $version.',
+    );
+  }
+  return '$notes\n';
+}
+
+RegExpMatch _releaseHeading(String changelog, String version) {
   final headingPattern = RegExp(
-    '^## \\[${RegExp.escape(expectedVersion)}\\] - '
+    '^## \\[${RegExp.escape(version)}\\] - '
     r'(\d{4}-\d{2}-\d{2})[ \t]*$',
     multiLine: true,
   );
   final headings = headingPattern.allMatches(changelog).toList();
   if (headings.length != 1) {
     throw ReleaseToolException(
-      'CHANGELOG.md must contain exactly one release heading for '
-      '$expectedVersion.',
+      'CHANGELOG.md must contain exactly one release heading for $version.',
     );
   }
-
-  final date = headings.single.group(1)!;
-  if (!_isValidDate(date)) {
-    throw ReleaseToolException(
-      'CHANGELOG.md has an invalid release date for $expectedVersion: $date.',
-    );
-  }
+  return headings.single;
 }
 
 bool _isValidDate(String value) {


### PR DESCRIPTION
## 概要

Issue #29 Phase 4として、pub.devへの公開成功後にGitHub Releaseを自動生成します。

## 変更内容

- `dart run tool/release_notes.dart <version>`を追加
  - `CHANGELOG.md`から対象バージョンの本文だけを抽出
  - 対象見出しの重複・欠落・本文なしを検出
- publish workflowへ`release`ジョブを追加
  - pub.devのpublish成功後のみ実行
  - push済みタグの存在を`--verify-tag`で確認
  - CHANGELOGの対象セクションをRelease本文に使用
  - プレリリース版を`--prerelease --latest=false`で作成
  - 安定版は通常のReleaseとして作成
- リリースノート抽出の単体テストを追加

## 実行順序

1. バージョン整合を検証
2. pub.devへOIDC公開
3. GitHub Releaseを作成

公開に失敗した場合、GitHub Releaseは作成されません。

## 確認内容

- 既存`1.0.0-beta.3`のCHANGELOG本文を実データから抽出
- stable／prereleaseのオプション分岐
- publish workflowのYAML構文確認
- `dart format --output=none --set-exit-if-changed .`
- `dart analyze --fatal-infos`
- `dart run build_runner build`
- `dart test --exclude-tags e2e`（468件成功）
- `dart pub publish --dry-run`（警告0件）

実際のGitHub Release作成は、次回のリリースタグpush時に確認します。

Relates to #29
