### PR TITLE
misskey_api_core 統合の受け入れ準備

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `MisskeyCustomEmoji.roleIdsThatCanNotBeUsedThisEmojiAsReaction` for roles denied from using a custom emoji as a reaction
+- Added migration guides from `misskey_api_core` to all six README languages
 - Added CI checks for formatting, static analysis, generated code, unit tests, and package validation on the minimum and stable Dart SDKs (issue #29)
 - Added OIDC-based pub.dev publishing and release version update/verification tooling (issue #29)
 - Added automatic GitHub Release creation from the matching CHANGELOG section after a successful pub.dev publication (issue #29)

--- a/README.de.md
+++ b/README.de.md
@@ -149,6 +149,37 @@ final client = MisskeyClient(
 );
 ```
 
+## Migration von misskey_api_core
+
+### API-Zuordnung
+
+| misskey_api_core | misskey_client |
+|---|---|
+| `MisskeyHttpClient(config: ..., tokenProvider: ...)` | `MisskeyClient(config: ..., tokenProvider: ...)` |
+| `MisskeyApiConfig(baseUrl: ...)` | `MisskeyClientConfig(baseUrl: ...)` |
+| `http.send<T>('/emojis', ...)` | Die entsprechende typisierte Methode, z. B. `client.meta.getEmojis()` |
+| `MetaClient(http).getMeta()` | `client.meta.getMeta()` |
+| `MisskeyApiException` | Die versiegelte Hierarchie mit `MisskeyApiException`, `MisskeyUnauthorizedException`, `MisskeyForbiddenException`, `MisskeyRateLimitException` und weiteren |
+| `RequestOptions(authRequired: false)` | Wird intern von typisierten Methoden verarbeitet; aufrufender Code muss nichts angeben |
+| `Logger` / `FunctionLogger` | Klassen mit denselben Namen |
+| `kReleaseMode` / `kDebugMode` | Nicht Teil der öffentlichen API; siehe unten |
+
+### Namenskonflikt bei MisskeyApiException
+
+Beide Pakete definieren `MisskeyApiException`, die Klassen haben jedoch unterschiedliche Inhalte und keine Vererbungsbeziehung. Die Variante aus `misskey_api_core` ist eine einfache Klasse, während die Variante aus `misskey_client` von `MisskeyClientException` erbt und einen `statusCode` erfordert. Wenn während der Migration beide Pakete importiert werden, verhindert ein Präfix den Konflikt:
+
+```dart
+import 'package:misskey_api_core/misskey_api_core.dart' as core;
+```
+
+### Konstanten für den Build-Modus
+
+`misskey_api_core` exportierte `kReleaseMode` und `kDebugMode`; `misskey_client` nimmt sie nicht in seine öffentliche API auf. Es handelt sich um allgemeine Hilfsfunktionen ohne Bezug zu Misskey. Flutter-Anwendungen sollten die Konstanten aus `package:flutter/foundation.dart` verwenden; reine Dart-Anwendungen können `bool.fromEnvironment('dart.vm.product')` nutzen. Steuern Sie das Client-Logging über `MisskeyClientConfig.enableLog`, zum Beispiel mit `enableLog: kDebugMode`.
+
+### Low-Level-HTTP-Zugriff
+
+Das Low-Level-Gegenstück zu `MisskeyHttpClient.send<T>()` ist nicht öffentlich. `misskey_client` deckt 25 API-Domänen ab; verwenden Sie daher die typisierten Methoden. Falls ein benötigter Endpunkt fehlt, melden Sie ihn bitte in einem GitHub-Issue, damit er der typisierten API hinzugefügt werden kann.
+
 ## Dokumentation
 
 - API-Referenz: https://librarylibrarian.github.io/misskey_client/

--- a/README.fr.md
+++ b/README.fr.md
@@ -149,6 +149,37 @@ final client = MisskeyClient(
 );
 ```
 
+## Migration depuis misskey_api_core
+
+### Correspondance des API
+
+| misskey_api_core | misskey_client |
+|---|---|
+| `MisskeyHttpClient(config: ..., tokenProvider: ...)` | `MisskeyClient(config: ..., tokenProvider: ...)` |
+| `MisskeyApiConfig(baseUrl: ...)` | `MisskeyClientConfig(baseUrl: ...)` |
+| `http.send<T>('/emojis', ...)` | La méthode typée correspondante, par exemple `client.meta.getEmojis()` |
+| `MetaClient(http).getMeta()` | `client.meta.getMeta()` |
+| `MisskeyApiException` | La hiérarchie scellée comprenant `MisskeyApiException`, `MisskeyUnauthorizedException`, `MisskeyForbiddenException`, `MisskeyRateLimitException`, etc. |
+| `RequestOptions(authRequired: false)` | Géré en interne par les méthodes typées ; aucun paramètre n'est nécessaire côté appelant |
+| `Logger` / `FunctionLogger` | Classes portant les mêmes noms |
+| `kReleaseMode` / `kDebugMode` | Non inclus dans l'API publique ; voir ci-dessous |
+
+### Conflit de nom MisskeyApiException
+
+Les deux packages définissent `MisskeyApiException`, mais les classes ont un contenu différent et aucune relation d'héritage. La version de `misskey_api_core` est une classe simple, tandis que celle de `misskey_client` étend `MisskeyClientException` et exige un `statusCode`. Lorsque les deux packages sont importés pendant la migration, utilisez un préfixe pour éviter le conflit :
+
+```dart
+import 'package:misskey_api_core/misskey_api_core.dart' as core;
+```
+
+### Constantes du mode de compilation
+
+`misskey_api_core` exportait `kReleaseMode` et `kDebugMode`, mais `misskey_client` ne les inclut pas dans son API publique. Il s'agit d'utilitaires généraux sans rapport avec Misskey. Les applications Flutter doivent utiliser ceux de `package:flutter/foundation.dart` ; les applications Dart pur peuvent utiliser `bool.fromEnvironment('dart.vm.product')`. Pour contrôler la journalisation du client, transmettez la valeur à `MisskeyClientConfig.enableLog`, par exemple `enableLog: kDebugMode`.
+
+### Accès HTTP de bas niveau
+
+L'équivalent de bas niveau de `MisskeyHttpClient.send<T>()` n'est pas public. `misskey_client` couvre 25 domaines d'API ; utilisez donc les méthodes typées. Si un point de terminaison nécessaire manque, veuillez le signaler dans une issue GitHub afin qu'il soit ajouté à l'API typée.
+
 ## Documentation
 
 - Référence API : https://librarylibrarian.github.io/misskey_client/

--- a/README.ja.md
+++ b/README.ja.md
@@ -148,6 +148,37 @@ final client = MisskeyClient(
 );
 ```
 
+## misskey_api_core からの移行
+
+### API 対応表
+
+| misskey_api_core | misskey_client |
+|---|---|
+| `MisskeyHttpClient(config: ..., tokenProvider: ...)` | `MisskeyClient(config: ..., tokenProvider: ...)` |
+| `MisskeyApiConfig(baseUrl: ...)` | `MisskeyClientConfig(baseUrl: ...)` |
+| `http.send<T>('/emojis', ...)` | 対応する型付きメソッド（例：`client.meta.getEmojis()`） |
+| `MetaClient(http).getMeta()` | `client.meta.getMeta()` |
+| `MisskeyApiException` | `MisskeyApiException`、`MisskeyUnauthorizedException`、`MisskeyForbiddenException`、`MisskeyRateLimitException` などを含む sealed 階層 |
+| `RequestOptions(authRequired: false)` | 型付きメソッドが内部で処理するため、利用側の指定は不要 |
+| `Logger` / `FunctionLogger` | 同名クラス |
+| `kReleaseMode` / `kDebugMode` | 公開 API に含めない（下記参照） |
+
+### MisskeyApiException の名前衝突
+
+両パッケージに `MisskeyApiException` が存在しますが、内容も継承関係も異なります。`misskey_api_core` 版は単純なクラスである一方、`misskey_client` 版は `MisskeyClientException` を継承し、`statusCode` が必須です。移行中に両方のパッケージを import する場合は、接頭辞を付けて衝突を回避してください：
+
+```dart
+import 'package:misskey_api_core/misskey_api_core.dart' as core;
+```
+
+### ビルドモード定数
+
+`misskey_api_core` は `kReleaseMode` と `kDebugMode` を export していましたが、`misskey_client` の公開 API には含めません。これらは Misskey とは無関係な汎用ユーティリティです。Flutter アプリでは `package:flutter/foundation.dart` の定数を、pure Dart では `bool.fromEnvironment('dart.vm.product')` を使用してください。ログ出力は `MisskeyClientConfig.enableLog` で制御し、たとえば `enableLog: kDebugMode` のように渡します。
+
+### 低レベル HTTP アクセス
+
+`MisskeyHttpClient.send<T>()` に相当する低レベル API は公開しません。`misskey_client` は25の API ドメインを網羅しているため、型付きメソッドを使用してください。必要なエンドポイントが未実装の場合は、型付き API に追加できるよう GitHub issue で報告してください。
+
 ## ドキュメント
 
 - API リファレンス: https://librarylibrarian.github.io/misskey_client/

--- a/README.ko.md
+++ b/README.ko.md
@@ -149,6 +149,37 @@ final client = MisskeyClient(
 );
 ```
 
+## misskey_api_core에서 마이그레이션
+
+### API 대응표
+
+| misskey_api_core | misskey_client |
+|---|---|
+| `MisskeyHttpClient(config: ..., tokenProvider: ...)` | `MisskeyClient(config: ..., tokenProvider: ...)` |
+| `MisskeyApiConfig(baseUrl: ...)` | `MisskeyClientConfig(baseUrl: ...)` |
+| `http.send<T>('/emojis', ...)` | 대응하는 타입 지정 메서드(예: `client.meta.getEmojis()`) |
+| `MetaClient(http).getMeta()` | `client.meta.getMeta()` |
+| `MisskeyApiException` | `MisskeyApiException`, `MisskeyUnauthorizedException`, `MisskeyForbiddenException`, `MisskeyRateLimitException` 등을 포함하는 sealed 계층 구조 |
+| `RequestOptions(authRequired: false)` | 타입 지정 메서드가 내부에서 처리하므로 호출자가 지정할 필요 없음 |
+| `Logger` / `FunctionLogger` | 이름이 같은 클래스 |
+| `kReleaseMode` / `kDebugMode` | 공개 API에 포함하지 않음(아래 참조) |
+
+### MisskeyApiException 이름 충돌
+
+두 패키지 모두 `MisskeyApiException`을 정의하지만 클래스의 내용과 상속 관계가 다릅니다. `misskey_api_core` 버전은 단순 클래스인 반면, `misskey_client` 버전은 `MisskeyClientException`을 상속하며 `statusCode`가 필수입니다. 마이그레이션 중 두 패키지를 함께 import할 때는 접두사를 사용하여 충돌을 피하세요:
+
+```dart
+import 'package:misskey_api_core/misskey_api_core.dart' as core;
+```
+
+### 빌드 모드 상수
+
+`misskey_api_core`는 `kReleaseMode`와 `kDebugMode`를 export했지만, `misskey_client`의 공개 API에는 포함하지 않습니다. 이들은 Misskey와 무관한 범용 유틸리티입니다. Flutter 앱에서는 `package:flutter/foundation.dart`의 상수를 사용하고, 순수 Dart 앱에서는 `bool.fromEnvironment('dart.vm.product')`를 사용하세요. 클라이언트 로그는 `MisskeyClientConfig.enableLog`를 통해 제어하며, 예를 들어 `enableLog: kDebugMode`처럼 전달합니다.
+
+### 저수준 HTTP 접근
+
+`MisskeyHttpClient.send<T>()`에 해당하는 저수준 API는 공개하지 않습니다. `misskey_client`는 25개의 API 도메인을 지원하므로 타입 지정 메서드를 사용하세요. 필요한 엔드포인트가 구현되어 있지 않다면 타입 지정 API에 추가할 수 있도록 GitHub issue로 알려 주세요.
+
 ## 문서
 
 - API 레퍼런스: https://librarylibrarian.github.io/misskey_client/

--- a/README.md
+++ b/README.md
@@ -149,6 +149,37 @@ final client = MisskeyClient(
 );
 ```
 
+## Migrating from misskey_api_core
+
+### API mapping
+
+| misskey_api_core | misskey_client |
+|---|---|
+| `MisskeyHttpClient(config: ..., tokenProvider: ...)` | `MisskeyClient(config: ..., tokenProvider: ...)` |
+| `MisskeyApiConfig(baseUrl: ...)` | `MisskeyClientConfig(baseUrl: ...)` |
+| `http.send<T>('/emojis', ...)` | The corresponding typed method, such as `client.meta.getEmojis()` |
+| `MetaClient(http).getMeta()` | `client.meta.getMeta()` |
+| `MisskeyApiException` | The sealed hierarchy containing `MisskeyApiException`, `MisskeyUnauthorizedException`, `MisskeyForbiddenException`, `MisskeyRateLimitException`, and others |
+| `RequestOptions(authRequired: false)` | Handled internally by typed methods; callers do not need to specify it |
+| `Logger` / `FunctionLogger` | Classes with the same names |
+| `kReleaseMode` / `kDebugMode` | Not part of the public API; see below |
+
+### Exception name collision
+
+Both packages define `MisskeyApiException`, but the classes have different contents and no inheritance relationship. The `misskey_api_core` version is a simple class, while the `misskey_client` version extends `MisskeyClientException` and requires a `statusCode`. While importing both packages during migration, use a prefix to avoid the collision:
+
+```dart
+import 'package:misskey_api_core/misskey_api_core.dart' as core;
+```
+
+### Build mode constants
+
+`misskey_api_core` exported `kReleaseMode` and `kDebugMode`, but `misskey_client` does not. They are general-purpose utilities unrelated to Misskey. Flutter applications should import them from `package:flutter/foundation.dart`; pure Dart applications can use `bool.fromEnvironment('dart.vm.product')`. To control client logging, pass the value through `MisskeyClientConfig.enableLog`, for example `enableLog: kDebugMode`.
+
+### Low-level HTTP access
+
+The low-level equivalent of `MisskeyHttpClient.send<T>()` is not public. `misskey_client` covers 25 API domains, so use its typed methods. If an endpoint you need is missing, please report it in a GitHub issue so it can be added to the typed API.
+
 ## Documentation
 
 - API reference: https://librarylibrarian.github.io/misskey_client/

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -149,6 +149,37 @@ final client = MisskeyClient(
 );
 ```
 
+## 从 misskey_api_core 迁移
+
+### API 对应表
+
+| misskey_api_core | misskey_client |
+|---|---|
+| `MisskeyHttpClient(config: ..., tokenProvider: ...)` | `MisskeyClient(config: ..., tokenProvider: ...)` |
+| `MisskeyApiConfig(baseUrl: ...)` | `MisskeyClientConfig(baseUrl: ...)` |
+| `http.send<T>('/emojis', ...)` | 对应的强类型方法，例如 `client.meta.getEmojis()` |
+| `MetaClient(http).getMeta()` | `client.meta.getMeta()` |
+| `MisskeyApiException` | 包含 `MisskeyApiException`、`MisskeyUnauthorizedException`、`MisskeyForbiddenException`、`MisskeyRateLimitException` 等的密封层次结构 |
+| `RequestOptions(authRequired: false)` | 由强类型方法在内部处理，调用方无需指定 |
+| `Logger` / `FunctionLogger` | 同名类 |
+| `kReleaseMode` / `kDebugMode` | 不属于公共 API；详见下文 |
+
+### MisskeyApiException 名称冲突
+
+两个包都定义了 `MisskeyApiException`，但类的内容和继承关系不同。`misskey_api_core` 版本是简单类，而 `misskey_client` 版本继承 `MisskeyClientException`，并且必须提供 `statusCode`。迁移期间同时导入两个包时，请使用前缀避免冲突：
+
+```dart
+import 'package:misskey_api_core/misskey_api_core.dart' as core;
+```
+
+### 构建模式常量
+
+`misskey_api_core` 导出了 `kReleaseMode` 和 `kDebugMode`，但 `misskey_client` 不会将它们纳入公共 API。它们是与 Misskey 无关的通用工具。Flutter 应用应使用 `package:flutter/foundation.dart` 中的常量；纯 Dart 应用可使用 `bool.fromEnvironment('dart.vm.product')`。请通过 `MisskeyClientConfig.enableLog` 控制客户端日志，例如传入 `enableLog: kDebugMode`。
+
+### 低级 HTTP 访问
+
+与 `MisskeyHttpClient.send<T>()` 对应的低级 API 不会公开。`misskey_client` 已覆盖 25 个 API 域，请使用强类型方法。如果缺少您需要的端点，请通过 GitHub issue 报告，以便将其加入强类型 API。
+
 ## 文档
 
 - API 参考文档：https://librarylibrarian.github.io/misskey_client/

--- a/lib/src/api/account/account_api.dart
+++ b/lib/src/api/account/account_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../../client/misskey_http.dart';
 import '../../client/request_options.dart';
 import '../../internal/optional.dart';
@@ -18,6 +20,7 @@ class AccountApi {
       twoFactor = TwoFactorApi(http: http),
       webhooks = WebhooksApi(http: http);
 
+  @internal
   final MisskeyHttp http;
 
   /// Provides registry (client settings storage) APIs.

--- a/lib/src/api/account/registry_api.dart
+++ b/lib/src/api/account/registry_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../../client/misskey_http.dart';
 import '../../client/request_options.dart';
 import '../../models/account/misskey_registry_detail.dart';
@@ -10,6 +12,7 @@ import '../../models/account/misskey_registry_scope.dart';
 class RegistryApi {
   const RegistryApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Retrieves the value of a specific key (`/api/i/registry/get`).

--- a/lib/src/api/account/two_factor_api.dart
+++ b/lib/src/api/account/two_factor_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../../client/misskey_http.dart';
 import '../../models/account/misskey_totp_registration.dart';
 
@@ -9,6 +11,7 @@ import '../../models/account/misskey_totp_registration.dart';
 class TwoFactorApi {
   const TwoFactorApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Initiates TOTP two-factor authentication registration

--- a/lib/src/api/account/webhooks_api.dart
+++ b/lib/src/api/account/webhooks_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../../client/misskey_http.dart';
 import '../../client/request_options.dart';
 import '../../internal/optional.dart';
@@ -10,6 +12,7 @@ import '../../models/account/misskey_webhook.dart';
 class WebhooksApi {
   const WebhooksApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Creates a new webhook (`/api/i/webhooks/create`).

--- a/lib/src/api/admin/admin_abuse_reports_api.dart
+++ b/lib/src/api/admin/admin_abuse_reports_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../../client/misskey_http.dart';
 import '../../client/request_options.dart';
 import '../../models/admin/misskey_abuse_report_notification_recipient.dart';
@@ -11,6 +13,7 @@ import '../../models/admin/misskey_abuse_user_report.dart';
 class AdminAbuseReportsApi {
   const AdminAbuseReportsApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Fetches abuse reports (`/api/admin/abuse-user-reports`).

--- a/lib/src/api/admin/admin_accounts_api.dart
+++ b/lib/src/api/admin/admin_accounts_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../../client/misskey_http.dart';
 import '../../models/admin/misskey_admin_created_account.dart';
 import '../../models/misskey_user.dart';
@@ -6,6 +8,7 @@ import '../../models/misskey_user.dart';
 class AdminAccountsApi {
   const AdminAccountsApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Creates a new local account (`/api/admin/accounts/create`).

--- a/lib/src/api/admin/admin_ad_api.dart
+++ b/lib/src/api/admin/admin_ad_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../../client/misskey_http.dart';
 import '../../client/request_options.dart';
 import '../../models/admin/misskey_ad.dart';
@@ -8,6 +10,7 @@ import '../../models/admin/misskey_ad.dart';
 class AdminAdApi {
   const AdminAdApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Creates an advertisement (`/api/admin/ad/create`).

--- a/lib/src/api/admin/admin_announcements_api.dart
+++ b/lib/src/api/admin/admin_announcements_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../../client/misskey_http.dart';
 import '../../client/request_options.dart';
 import '../../internal/optional.dart';
@@ -11,6 +13,7 @@ import '../../models/admin/misskey_admin_announcement.dart';
 class AdminAnnouncementsApi {
   const AdminAnnouncementsApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Creates an announcement (`/api/admin/announcements/create`).

--- a/lib/src/api/admin/admin_api.dart
+++ b/lib/src/api/admin/admin_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../../client/misskey_http.dart';
 import '../../client/request_options.dart';
 import '../../internal/optional.dart';
@@ -15,6 +17,7 @@ import '../../models/misskey_user.dart';
 class AdminApi {
   const AdminApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Fetches the full instance settings (`/api/admin/meta`).

--- a/lib/src/api/admin/admin_avatar_decorations_api.dart
+++ b/lib/src/api/admin/admin_avatar_decorations_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../../client/misskey_http.dart';
 import '../../client/request_options.dart';
 import '../../internal/optional.dart';
@@ -11,6 +13,7 @@ import '../../models/admin/misskey_admin_avatar_decoration.dart';
 class AdminAvatarDecorationsApi {
   const AdminAvatarDecorationsApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Registers an avatar decoration

--- a/lib/src/api/admin/admin_captcha_api.dart
+++ b/lib/src/api/admin/admin_captcha_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../../client/misskey_http.dart';
 import '../../client/request_options.dart';
 import '../../models/admin/misskey_captcha_settings.dart';
@@ -8,6 +10,7 @@ import '../../models/admin/misskey_captcha_settings.dart';
 class AdminCaptchaApi {
   const AdminCaptchaApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Fetches the current CAPTCHA settings (`/api/admin/captcha/current`).

--- a/lib/src/api/admin/admin_drive_api.dart
+++ b/lib/src/api/admin/admin_drive_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../../client/misskey_http.dart';
 import '../../client/request_options.dart';
 import '../../models/misskey_drive_file.dart';
@@ -8,6 +10,7 @@ import '../../models/misskey_drive_file.dart';
 class AdminDriveApi {
   const AdminDriveApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Fetches drive files across all users (`/api/admin/drive/files`).

--- a/lib/src/api/admin/admin_emoji_api.dart
+++ b/lib/src/api/admin/admin_emoji_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../../client/misskey_http.dart';
 import '../../client/request_options.dart';
 import '../../internal/optional.dart';
@@ -10,6 +12,7 @@ import '../../models/server/emoji_detailed.dart';
 class AdminEmojiApi {
   const AdminEmojiApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Registers a custom emoji (`/api/admin/emoji/add`).

--- a/lib/src/api/admin/admin_federation_api.dart
+++ b/lib/src/api/admin/admin_federation_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../../client/misskey_http.dart';
 
 /// Provides federation management admin APIs (`/api/admin/federation/*`).
@@ -6,6 +8,7 @@ import '../../client/misskey_http.dart';
 class AdminFederationApi {
   const AdminFederationApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Deletes all cached files from a remote instance

--- a/lib/src/api/admin/admin_invite_api.dart
+++ b/lib/src/api/admin/admin_invite_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../../client/misskey_http.dart';
 import '../../client/request_options.dart';
 import '../../models/misskey_invite_code.dart';
@@ -6,6 +8,7 @@ import '../../models/misskey_invite_code.dart';
 class AdminInviteApi {
   const AdminInviteApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Creates invite codes (`/api/admin/invite/create`).

--- a/lib/src/api/admin/admin_queue_api.dart
+++ b/lib/src/api/admin/admin_queue_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../../client/misskey_http.dart';
 import '../../client/request_options.dart';
 import '../../models/admin/misskey_queue.dart';
@@ -12,6 +14,7 @@ import '../../models/admin/misskey_queue.dart';
 class AdminQueueApi {
   const AdminQueueApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Fetches aggregated job counts for the main queues

--- a/lib/src/api/admin/admin_relays_api.dart
+++ b/lib/src/api/admin/admin_relays_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../../client/misskey_http.dart';
 import '../../client/request_options.dart';
 import '../../models/admin/misskey_relay.dart';
@@ -8,6 +10,7 @@ import '../../models/admin/misskey_relay.dart';
 class AdminRelaysApi {
   const AdminRelaysApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Subscribes to a relay (`/api/admin/relays/add`).

--- a/lib/src/api/admin/admin_roles_api.dart
+++ b/lib/src/api/admin/admin_roles_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../../client/misskey_http.dart';
 import '../../client/request_options.dart';
 import '../../internal/optional.dart';
@@ -11,6 +13,7 @@ import '../../models/misskey_role_user.dart';
 class AdminRolesApi {
   const AdminRolesApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Fetches all roles (`/api/admin/roles/list`).

--- a/lib/src/api/admin/admin_system_webhook_api.dart
+++ b/lib/src/api/admin/admin_system_webhook_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../../client/misskey_http.dart';
 import '../../client/request_options.dart';
 import '../../models/admin/misskey_system_webhook.dart';
@@ -12,6 +14,7 @@ import '../../models/admin/misskey_system_webhook.dart';
 class AdminSystemWebhookApi {
   const AdminSystemWebhookApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Creates a system webhook (`/api/admin/system-webhook/create`).

--- a/lib/src/api/announcements_api.dart
+++ b/lib/src/api/announcements_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../client/auth_mode.dart';
 import '../client/misskey_http.dart';
 import '../client/request_options.dart';
@@ -10,6 +12,7 @@ import '../models/misskey_announcement.dart';
 class AnnouncementsApi {
   const AnnouncementsApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Retrieves the list of announcements (`/api/announcements`).

--- a/lib/src/api/antennas_api.dart
+++ b/lib/src/api/antennas_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../client/misskey_http.dart';
 import '../client/request_options.dart';
 import '../internal/optional.dart';
@@ -12,6 +14,7 @@ import '../models/misskey_note.dart';
 class AntennasApi {
   const AntennasApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Creates an antenna (`/api/antennas/create`).

--- a/lib/src/api/ap_api.dart
+++ b/lib/src/api/ap_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../client/misskey_http.dart';
 import '../models/ap_show_result.dart';
 
@@ -7,6 +9,7 @@ import '../models/ap_show_result.dart';
 class ApApi {
   const ApApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Resolves a user or note from an ActivityPub URI (`/api/ap/show`).

--- a/lib/src/api/blocking_api.dart
+++ b/lib/src/api/blocking_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../client/misskey_http.dart';
 import '../client/request_options.dart';
 import '../models/misskey_blocking.dart';
@@ -9,6 +11,7 @@ import '../models/misskey_user.dart';
 class BlockingApi {
   const BlockingApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Blocks a user (`/api/blocking/create`).

--- a/lib/src/api/channels/channel_mute_api.dart
+++ b/lib/src/api/channels/channel_mute_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../../client/misskey_http.dart';
 import '../../client/request_options.dart';
 import '../../models/misskey_channel.dart';
@@ -8,6 +10,7 @@ import '../../models/misskey_channel.dart';
 class ChannelMuteApi {
   const ChannelMuteApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Mutes a channel.

--- a/lib/src/api/charts_api.dart
+++ b/lib/src/api/charts_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../client/auth_mode.dart';
 import '../client/misskey_http.dart';
 import '../client/request_options.dart';
@@ -12,6 +14,7 @@ class ChartsApi {
   const ChartsApi({required this.http});
 
   /// The HTTP client.
+  @internal
   final MisskeyHttp http;
 
   /// Retrieves active user statistics (`/api/charts/active-users`).

--- a/lib/src/api/chat/chat_messages_api.dart
+++ b/lib/src/api/chat/chat_messages_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../../client/misskey_http.dart';
 import '../../client/request_options.dart';
 import '../../models/chat/misskey_chat_message.dart';
@@ -10,6 +12,7 @@ import '../../models/chat/misskey_chat_message.dart';
 class ChatMessagesApi {
   const ChatMessagesApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Sends a message to a user (`/api/chat/messages/create-to-user`).

--- a/lib/src/api/chat/chat_rooms_api.dart
+++ b/lib/src/api/chat/chat_rooms_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../../client/misskey_http.dart';
 import '../../client/request_options.dart';
 import '../../models/chat/misskey_chat_room.dart';
@@ -12,6 +14,7 @@ import '../../models/chat/misskey_chat_room_member.dart';
 class ChatRoomsApi {
   const ChatRoomsApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Creates a chat room (`/api/chat/rooms/create`).

--- a/lib/src/api/clips_api.dart
+++ b/lib/src/api/clips_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../client/misskey_http.dart';
 import '../client/request_options.dart';
 import '../internal/optional.dart';
@@ -13,6 +15,7 @@ import '../models/misskey_note.dart';
 class ClipsApi {
   const ClipsApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Creates a clip (`/api/clips/create`).

--- a/lib/src/api/drive/drive_files_api.dart
+++ b/lib/src/api/drive/drive_files_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import 'package:dio/dio.dart' show FormData, MultipartFile;
 
 import '../../client/misskey_http.dart';
@@ -17,6 +19,7 @@ class DriveFilesApi {
   const DriveFilesApi({required this.http});
 
   /// The HTTP client used for requests.
+  @internal
   final MisskeyHttp http;
 
   /// Retrieves a list of Drive files (`/api/drive/files`).

--- a/lib/src/api/drive/drive_folders_api.dart
+++ b/lib/src/api/drive/drive_folders_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../../client/misskey_http.dart';
 import '../../client/request_options.dart';
 import '../../models/misskey_drive_folder.dart';
@@ -11,6 +13,7 @@ class DriveFoldersApi {
   const DriveFoldersApi({required this.http});
 
   /// The HTTP client used for requests.
+  @internal
   final MisskeyHttp http;
 
   /// Retrieves a list of Drive folders (`/api/drive/folders`).

--- a/lib/src/api/drive/drive_stats_api.dart
+++ b/lib/src/api/drive/drive_stats_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../../client/auth_mode.dart';
 import '../../client/misskey_http.dart';
 import '../../client/request_options.dart';
@@ -12,6 +14,7 @@ class DriveStatsApi {
   const DriveStatsApi({required this.http});
 
   /// The HTTP client used for requests.
+  @internal
   final MisskeyHttp http;
 
   /// Retrieves the Drive capacity information for the authenticated user

--- a/lib/src/api/federation_api.dart
+++ b/lib/src/api/federation_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../client/auth_mode.dart';
 import '../client/misskey_http.dart';
 import '../client/request_options.dart';
@@ -13,6 +15,7 @@ import '../models/misskey_user.dart';
 class FederationApi {
   const FederationApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Retrieves a list of federated instances (`/api/federation/instances`).

--- a/lib/src/api/flash_api.dart
+++ b/lib/src/api/flash_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../client/auth_mode.dart';
 import '../client/misskey_http.dart';
 import '../client/request_options.dart';
@@ -12,6 +14,7 @@ import '../models/users/misskey_flash_like.dart';
 class FlashApi {
   const FlashApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Creates a Flash (`/api/flash/create`).

--- a/lib/src/api/following_requests_api.dart
+++ b/lib/src/api/following_requests_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../client/misskey_http.dart';
 import '../client/request_options.dart';
 import '../models/misskey_follow_request.dart';
@@ -10,6 +12,7 @@ import '../models/misskey_user.dart';
 class FollowingRequestsApi {
   const FollowingRequestsApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Retrieves received follow requests (`/api/following/requests/list`).

--- a/lib/src/api/gallery/gallery_api.dart
+++ b/lib/src/api/gallery/gallery_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../../client/auth_mode.dart';
 import '../../client/misskey_http.dart';
 import '../../client/request_options.dart';
@@ -13,6 +15,7 @@ import '../../models/gallery/misskey_gallery_post.dart';
 class GalleryApi {
   const GalleryApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Retrieves featured gallery posts (`/api/gallery/featured`).

--- a/lib/src/api/hashtags_api.dart
+++ b/lib/src/api/hashtags_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../client/auth_mode.dart';
 import '../client/misskey_http.dart';
 import '../client/request_options.dart';
@@ -11,6 +13,7 @@ import '../models/misskey_user.dart';
 class HashtagsApi {
   const HashtagsApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Fetches a list of hashtags (`/api/hashtags/list`).

--- a/lib/src/api/invite_api.dart
+++ b/lib/src/api/invite_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../client/misskey_http.dart';
 import '../client/request_options.dart';
 import '../models/misskey_invite_code.dart';
@@ -10,6 +12,7 @@ import '../models/misskey_invite_code.dart';
 class InviteApi {
   const InviteApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Creates a new invite code (`/api/invite/create`).

--- a/lib/src/api/meta_api.dart
+++ b/lib/src/api/meta_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../client/auth_mode.dart';
 import '../client/misskey_http.dart';
 import '../client/request_options.dart';
@@ -20,6 +22,7 @@ class MetaApi {
   MetaApi({required this.http});
 
   /// HTTP client.
+  @internal
   final MisskeyHttp http;
 
   Meta? _cached;

--- a/lib/src/api/mute_api.dart
+++ b/lib/src/api/mute_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../client/misskey_http.dart';
 import '../client/request_options.dart';
 import '../models/misskey_muting.dart';
@@ -8,6 +10,7 @@ import '../models/misskey_muting.dart';
 class MuteApi {
   const MuteApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Mutes a user (`/api/mute/create`).

--- a/lib/src/api/notes_api.dart
+++ b/lib/src/api/notes_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../client/auth_mode.dart';
 import '../client/misskey_http.dart';
 import '../client/request_options.dart';
@@ -15,6 +17,7 @@ import '../models/misskey_note_translation.dart';
 class NotesApi {
   const NotesApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Fetches public notes (`/api/notes`).

--- a/lib/src/api/notifications_api.dart
+++ b/lib/src/api/notifications_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../client/misskey_http.dart';
 import '../client/request_options.dart';
 import '../models/misskey_notification.dart';
@@ -6,6 +8,7 @@ import '../models/misskey_notification.dart';
 class NotificationsApi {
   const NotificationsApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Fetches a list of notifications (`/api/i/notifications`).

--- a/lib/src/api/pages_api.dart
+++ b/lib/src/api/pages_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../client/auth_mode.dart';
 import '../client/misskey_http.dart';
 import '../client/request_options.dart';
@@ -13,6 +15,7 @@ import '../models/users/misskey_page.dart';
 class PagesApi {
   const PagesApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Retrieves page details by page ID (`/api/pages/show`).

--- a/lib/src/api/renote_mute_api.dart
+++ b/lib/src/api/renote_mute_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../client/misskey_http.dart';
 import '../client/request_options.dart';
 import '../models/misskey_renote_muting.dart';
@@ -10,6 +12,7 @@ import '../models/misskey_renote_muting.dart';
 class RenoteMuteApi {
   const RenoteMuteApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Mutes renotes from a user (`/api/renote-mute/create`).

--- a/lib/src/api/roles_api.dart
+++ b/lib/src/api/roles_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../client/auth_mode.dart';
 import '../client/misskey_http.dart';
 import '../client/request_options.dart';
@@ -12,6 +14,7 @@ import '../models/misskey_role_user.dart';
 class RolesApi {
   const RolesApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Fetches the list of public roles (`/api/roles/list`).

--- a/lib/src/api/sw_api.dart
+++ b/lib/src/api/sw_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../client/misskey_http.dart';
 import '../client/request_options.dart';
 import '../models/sw/misskey_sw_registration.dart';
@@ -11,6 +13,7 @@ class SwApi {
   const SwApi({required this.http});
 
   /// HTTP client.
+  @internal
   final MisskeyHttp http;
 
   /// Registers for push notifications (`/api/sw/register`).

--- a/lib/src/api/users/user_lists_api.dart
+++ b/lib/src/api/users/user_lists_api.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import '../../client/auth_mode.dart';
 import '../../client/misskey_http.dart';
 import '../../client/request_options.dart';
@@ -8,6 +10,7 @@ import '../../models/users/misskey_user_list_membership.dart';
 class UserListsApi {
   const UserListsApi({required this.http});
 
+  @internal
   final MisskeyHttp http;
 
   /// Fetches user lists.

--- a/lib/src/client/misskey_client.dart
+++ b/lib/src/client/misskey_client.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:meta/meta.dart';
 
 import '../api/account/account_api.dart';
 import '../api/admin/admin_abuse_reports_api.dart';
@@ -105,6 +106,7 @@ class MisskeyClient {
   }
 
   /// The underlying HTTP client used for all API requests.
+  @internal
   final MisskeyHttp http;
 
   /// Account and profile management API.

--- a/lib/src/models/misskey_custom_emoji.dart
+++ b/lib/src/models/misskey_custom_emoji.dart
@@ -13,6 +13,7 @@ class MisskeyCustomEmoji {
     this.localOnly,
     this.isSensitive,
     this.roleIdsThatCanBeUsedThisEmojiAsReaction,
+    this.roleIdsThatCanNotBeUsedThisEmojiAsReaction,
   });
 
   // Misskey API may return emoji objects in different formats.
@@ -45,4 +46,7 @@ class MisskeyCustomEmoji {
 
   /// The role IDs that are allowed to use this emoji as a reaction.
   final List<String>? roleIdsThatCanBeUsedThisEmojiAsReaction;
+
+  /// The role IDs that are not allowed to use this emoji as a reaction.
+  final List<String>? roleIdsThatCanNotBeUsedThisEmojiAsReaction;
 }

--- a/lib/src/models/misskey_custom_emoji.g.dart
+++ b/lib/src/models/misskey_custom_emoji.g.dart
@@ -20,6 +20,10 @@ MisskeyCustomEmoji _$MisskeyCustomEmojiFromJson(Map<String, dynamic> json) =>
           (json['roleIdsThatCanBeUsedThisEmojiAsReaction'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList(),
+      roleIdsThatCanNotBeUsedThisEmojiAsReaction:
+          (json['roleIdsThatCanNotBeUsedThisEmojiAsReaction'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList(),
     );
 
 Map<String, dynamic> _$MisskeyCustomEmojiToJson(MisskeyCustomEmoji instance) =>
@@ -32,4 +36,6 @@ Map<String, dynamic> _$MisskeyCustomEmojiToJson(MisskeyCustomEmoji instance) =>
       'isSensitive': instance.isSensitive,
       'roleIdsThatCanBeUsedThisEmojiAsReaction':
           instance.roleIdsThatCanBeUsedThisEmojiAsReaction,
+      'roleIdsThatCanNotBeUsedThisEmojiAsReaction':
+          instance.roleIdsThatCanNotBeUsedThisEmojiAsReaction,
     };


### PR DESCRIPTION
## 概要

`misskey_api_core` を本パッケージに統合し一本化する作業（Refs #31）の第1段階として、受け入れ準備を行う。

本PR単体では #31 は完了しない。下流の [misskey_emoji#1](https://github.com/LibraryLibrarian/misskey_emoji/issues/1) と [misskey_mfm_renderer#25](https://github.com/LibraryLibrarian/misskey_mfm_renderer/issues/25) の移行がこのPRを待っている状態であり、**両者をアンブロックすることが本PRの主目的**である。

## 前提となる設計判断

事前検討で以下の4点を確定した。本PRはこの判断に従う。

### 判断1: 低レベル HTTP は公開 API に含めない

現状、`MisskeyClient.http` および各APIクラスの `http` は public フィールドである一方、型 `MisskeyHttp` と `RequestOptions` は `lib/misskey_client.dart` から export されていない。そのため外部からは `client.http.send<T>('/foo')` を呼べるが `options:` を渡せず、`AuthMode.required` 固定でしか使えないという中途半端な状態になっていた。

これが「export し忘れ」ではなく「意図的に閉じている」ことを明示するため `@internal` を付与する。未実装エンドポイントは脱出ハッチの公開ではなく、本体への型付き API 実装で解決する方針（#11 と整合）。

### 判断2: `kReleaseMode` / `kDebugMode` は export しない

`misskey_api_core` は export していたが、Misskey とは無関係な汎用ユーティリティであるため公開 API に含めない。調査の結果、ワークスペース内で `misskey_api_core` 版を import している箇所は皆無であり、Flutter 側は `package:flutter/foundation.dart` を使用していた。ログ制御の入口は `MisskeyClientConfig.enableLog` で既に足りている。

### 判断3: `MisskeyApiException` は改名しない

`misskey_api_core` と同名で衝突するが、本パッケージの命名（`MisskeyClientException` を頂点とする sealed 階層）は一貫しており、衝突する側は廃止される。移行期間の一時的な衝突のために安定版の命名は変更せず、移行ガイドで `as` 付き import による回避を案内する。

### 判断4: モデルのフィールド追加は単発で入れる

#18〜#22 のモデル欠落フィールド一括補完を待たず、下流のブロッカーとなっている1フィールドのみを先行して追加する。nullable 追加のため後方互換。

## 変更内容

### モデル

`MisskeyCustomEmoji` に `roleIdsThatCanNotBeUsedThisEmojiAsReaction`（`List<String>?`）を追加した。

`misskey_emoji` の `EmojiDto` / `EmojiRecord` が `denyRoleIds` として公開モデルに保持しているフィールドであり、これが無いと `misskey_emoji` を本パッケージに載せ替えられなかった。既存の `roleIdsThatCanBeUsedThisEmojiAsReaction` に合わせ、`JsonKey` でのリネームは行わず Misskey API の生のフィールド名のままとしている。

- `lib/src/models/misskey_custom_emoji.dart`
- `lib/src/models/misskey_custom_emoji.g.dart`（`build_runner` により再生成）

### `@internal` の付与

- `lib/src/client/misskey_client.dart` — `MisskeyClient.http`
- `lib/src/api/` 配下 46ファイル — 各APIクラスの `http`

`@internal` は同一パッケージ内からの参照には警告を出さないため、内部コードおよびテストへの影響はない。export リスト（`lib/misskey_client.dart`）は変更していない。

### ドキュメント

README 全6言語に「`misskey_api_core` からの移行」セクションを追加した。

- `README.md` / `README.ja.md` / `README.zh-Hans.md` / `README.de.md` / `README.fr.md` / `README.ko.md`

記載内容は、API 対応表・`MisskeyApiException` の名前衝突と回避方法・ビルドモード定数の扱い・低レベル HTTP を公開しない方針の4項目。

`CHANGELOG.md` の Unreleased セクションに追記した。**`pubspec.yaml` の version 変更および pub.dev への公開は本PRでは行わない**（別途対応）。

## 検証

| 項目 | 結果 |
|---|---|
| `dart analyze` | No issues found |
| `dart format --set-exit-if-changed` | 287ファイル、差分なし |
| `dart test` | 468件成功 |
| E2E | 6スイートをスキップ（実サーバー環境が必要） |
| `build_runner` | 生成物を更新済み・コミットに含む |
| `@internal` 付与件数 | APIクラス46件＋メインクライアント1件 |

## 調査で判明し、対応不要となった項目

#31 で「要確認」としていた2項目は、調査の結果いずれも対応不要と判明した。

- **`Retry-After` は既に充足**。`MisskeyRateLimitException` が `retryAfter` を保持し、`dio_error_handler.dart` がヘッダをパースしている。`misskey_api_core`（汎用例外に付与）より設計が良く、429専用の型に分かれている
- **`RequestOptions.extra` は追加不要**。`misskey_api_core` の `extra` は利用者向け機能ではなく、インターセプタへ `authRequired` を渡す実装詳細の露出だった。本パッケージは同じことを `AuthMode` 経由で内部処理している

#31 のチェックリストは本PRのマージ後に更新する。

## スコープ外

- Streaming 機能の実装（#30）
- #18〜#22 のモデル欠落フィールドの一括補完
- `misskey_api_core` 側リポジトリへの変更、および discontinued 設定
- pub.dev への公開、`pubspec.yaml` の version 変更
