### PR TITLE
merge: 1.0.0-beta.4をdevelopへ反映

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.4] - 2026-08-13
+
 ### Added
 
 - Added `MisskeyCustomEmoji.roleIdsThatCanNotBeUsedThisEmojiAsReaction` for roles denied from using a custom emoji as a reaction
@@ -126,6 +128,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `i/2fa/update-key` name parameter changed to optional
 
+[1.0.0-beta.4]: https://github.com/LibraryLibrarian/misskey_client/releases/tag/v1.0.0-beta.4
 [1.0.0-beta.3]: https://github.com/LibraryLibrarian/misskey_client/releases/tag/v1.0.0-beta.3
 [1.0.0-beta.2]: https://github.com/LibraryLibrarian/misskey_client/releases/tag/v1.0.0-beta.2
 [1.0.0-beta.1]: https://github.com/LibraryLibrarian/misskey_client/releases/tag/v1.0.0-beta.1

--- a/README.de.md
+++ b/README.de.md
@@ -22,7 +22,7 @@ Fügen Sie das Paket zu Ihrer `pubspec.yaml` hinzu:
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.3
+  misskey_client: ^1.0.0-beta.4
 ```
 
 Führen Sie anschließend aus:

--- a/README.fr.md
+++ b/README.fr.md
@@ -22,7 +22,7 @@ Ajoutez le package à votre `pubspec.yaml` :
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.3
+  misskey_client: ^1.0.0-beta.4
 ```
 
 Puis exécutez :

--- a/README.ja.md
+++ b/README.ja.md
@@ -21,7 +21,7 @@
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.3
+  misskey_client: ^1.0.0-beta.4
 ```
 
 その後、以下を実行します：

--- a/README.ko.md
+++ b/README.ko.md
@@ -22,7 +22,7 @@
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.3
+  misskey_client: ^1.0.0-beta.4
 ```
 
 그런 다음 실행합니다:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add the package to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.3
+  misskey_client: ^1.0.0-beta.4
 ```
 
 Then run:

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -22,7 +22,7 @@
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.3
+  misskey_client: ^1.0.0-beta.4
 ```
 
 然后运行：

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -23,7 +23,7 @@ Add the dependency to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.3
+  misskey_client: ^1.0.0-beta.4
 ```
 
 Then fetch it:

--- a/docs/i18n/de/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/de/docusaurus-plugin-content-docs/current/getting-started.md
@@ -23,7 +23,7 @@ Fuegen Sie die Abhaengigkeit in Ihre `pubspec.yaml` ein:
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.3
+  misskey_client: ^1.0.0-beta.4
 ```
 
 Anschliessend laden Sie das Paket herunter:

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/getting-started.md
@@ -23,7 +23,7 @@ Ajoutez la dépendance à votre `pubspec.yaml` :
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.3
+  misskey_client: ^1.0.0-beta.4
 ```
 
 Puis récupérez-la :

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/getting-started.md
@@ -19,7 +19,7 @@ slug: /
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.3
+  misskey_client: ^1.0.0-beta.4
 ```
 
 その後、依存関係を取得します。

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started.md
@@ -23,7 +23,7 @@ Flutter, 서버 사이드 Dart, CLI 도구 등 Dart가 실행되는 모든 환�
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.3
+  misskey_client: ^1.0.0-beta.4
 ```
 
 그 다음 패키지를 가져옵니다:

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started.md
@@ -23,7 +23,7 @@ misskey_client 是一个纯 Dart 编写的 Misskey API 客户端库。
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.3
+  misskey_client: ^1.0.0-beta.4
 ```
 
 然后获取依赖：

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: misskey_client
-version: 1.0.0-beta.3
+version: 1.0.0-beta.4
 documentation: https://librarylibrarian.github.io/misskey_client/
 environment:
   sdk: ">=3.9.0 <4.0.0"


### PR DESCRIPTION
## 概要

1.0.0-beta.4のリリースコミットを`develop`へ反映します。

## 反映内容

- `pubspec.yaml`を`1.0.0-beta.4`へ更新
- README 6言語とgetting-started 6言語を`^1.0.0-beta.4`へ更新
- `CHANGELOG.md`のUnreleased内容を`1.0.0-beta.4`として確定
- GitHub Releaseへの参照リンクを追加

## 公開結果

- pub.dev: `misskey_client 1.0.0-beta.4`公開成功
- GitHub Release: `v1.0.0-beta.4`作成成功（prerelease）
- 自動公開ワークフロー: verify / publish / releaseすべて成功

Relates to #29
