### PR TITLE
misskey.io フォーク専用の絵文字フィールドを削除

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Removed `MisskeyCustomEmoji.roleIdsThatCanNotBeUsedThisEmojiAsReaction`, a breaking API change, because the field does not exist in upstream Misskey and is specific to the misskey.io fork
+
 ## [1.0.0-beta.4] - 2026-08-13
 
 ### Added

--- a/lib/src/models/misskey_custom_emoji.dart
+++ b/lib/src/models/misskey_custom_emoji.dart
@@ -13,7 +13,6 @@ class MisskeyCustomEmoji {
     this.localOnly,
     this.isSensitive,
     this.roleIdsThatCanBeUsedThisEmojiAsReaction,
-    this.roleIdsThatCanNotBeUsedThisEmojiAsReaction,
   });
 
   // Misskey API may return emoji objects in different formats.
@@ -46,7 +45,4 @@ class MisskeyCustomEmoji {
 
   /// The role IDs that are allowed to use this emoji as a reaction.
   final List<String>? roleIdsThatCanBeUsedThisEmojiAsReaction;
-
-  /// The role IDs that are not allowed to use this emoji as a reaction.
-  final List<String>? roleIdsThatCanNotBeUsedThisEmojiAsReaction;
 }

--- a/lib/src/models/misskey_custom_emoji.g.dart
+++ b/lib/src/models/misskey_custom_emoji.g.dart
@@ -20,10 +20,6 @@ MisskeyCustomEmoji _$MisskeyCustomEmojiFromJson(Map<String, dynamic> json) =>
           (json['roleIdsThatCanBeUsedThisEmojiAsReaction'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList(),
-      roleIdsThatCanNotBeUsedThisEmojiAsReaction:
-          (json['roleIdsThatCanNotBeUsedThisEmojiAsReaction'] as List<dynamic>?)
-              ?.map((e) => e as String)
-              .toList(),
     );
 
 Map<String, dynamic> _$MisskeyCustomEmojiToJson(MisskeyCustomEmoji instance) =>
@@ -36,6 +32,4 @@ Map<String, dynamic> _$MisskeyCustomEmojiToJson(MisskeyCustomEmoji instance) =>
       'isSensitive': instance.isSensitive,
       'roleIdsThatCanBeUsedThisEmojiAsReaction':
           instance.roleIdsThatCanBeUsedThisEmojiAsReaction,
-      'roleIdsThatCanNotBeUsedThisEmojiAsReaction':
-          instance.roleIdsThatCanNotBeUsedThisEmojiAsReaction,
     };


### PR DESCRIPTION
## 概要

`MisskeyCustomEmoji.roleIdsThatCanNotBeUsedThisEmojiAsReaction` を削除する。

このフィールドは #38 で追加し `1.0.0-beta.4` として公開したが、その後の調査で**本家 Misskey には存在せず misskey.io フォーク専用**であることが判明したため撤回する。

**公開済み API からの破壊的削除**にあたる。

## 削除理由

本パッケージは本家 Misskey の API を対象とし、misskey.io / Sharkey / CherryPick 等のフォーク専用仕様はモデル化しない方針である。

追加時の判断は「`misskey_emoji` の `EmojiDto` / `EmojiRecord` に `denyRoleIds` があるのに `MisskeyCustomEmoji` に無いのは欠落である」というライブラリ間のモデル突き合わせに基づくもので、**上流スキーマの実在性を検証していなかった**。

## 検証根拠

| 検証対象 | 結果 |
|---|---|
| Misskey 2026.5.1 のソース全体（スペル揺れ含む全文検索） | **0件** |
| DB エンティティ `models/Emoji.ts` | allow のみ |
| 稼働中 PostgreSQL の実テーブル（`\d emoji`） | allow のみ。deny カラム無し |
| マイグレーション | allow の ADD が1本のみ。**deny の ADD も DROP も存在しない** |
| `admin/emoji/add` / `update` のパラメータ | allow のみ。deny を設定する手段が無い |
| ロケール `ja-JP.yml` | allow のみ |
| 実サーバーの `/api/emojis`（絵文字264件） | 該当キー **0件** |
| 実サーバーの `/api/emoji`（Detailed） | 該当キー **0件** |
| misskey.io の実データ（13,252件） | 該当キー **0件** |

マイグレーションに DROP が存在しないことから、本家の DB レイヤーには一度も存在しなかったと言える。

なお misskey.io の公開 OpenAPI スペック（`2025.4.1-io.12b`）には `EmojiSimple` / `EmojiDetailed` / `admin/emoji/{add,update}` の4箇所に定義が存在する。フォーク専用仕様であることの裏付けであると同時に、**実データでは1件も使われていない**ことも確認済み。

## 影響

- **クラッシュは発生しない。** `@JsonSerializable()` は全97箇所で `disallowUnrecognizedKeys` を設定しておらず、レスポンスに未知フィールドが含まれてもパースは成功し無視される
- `stream_app` は `MisskeyCustomEmoji` を1箇所も参照していないため、追随による修正は不要
- `roleIdsThatCanBeUsedThisEmojiAsReaction`（allow版）は本家に存在するため**変更しない**

## 将来 deny 判定が必要になった場合

`MisskeyCustomEmoji` に `raw`（生JSON保持）を追加するのではなく、`MetaApi.getEmojisRaw()` のような**生JSONを返すメソッドを個別に追加する**方針を CLAUDE.md に記録した。本PRでは実装しない。

`raw` フィールド方式は全利用者が常時メモリコストを負担する（絵文字13,252件で約 +4.4MB を実測）のに対し、生JSON返却メソッドなら呼び出し時のみコストが発生し既存利用者への影響がゼロであるため。

あわせて、フォーク対応の線引きと未知フィールドの扱いも CLAUDE.md に明文化した（CLAUDE.md は `.git/info/exclude` により追跡対象外のため、本PRの差分には含まれない）。

## 下流への影響

`misskey_emoji` でも `EmojiRecord.denyRoleIds` の削除が必要になる。同パッケージ内に読み手が1つも無い（`search.dart` は常に `const []` を渡すのみ）ことを確認済み。別リポジトリのため本PRの範囲外で、[LibraryLibrarian/misskey_emoji#1](https://github.com/LibraryLibrarian/misskey_emoji/issues/1) に作業項目を追記済み。

## 検証

| 項目 | 結果 |
|---|---|
| `dart analyze` | No issues found |
| `dart format --set-exit-if-changed` | 287ファイル、差分なし |
| `dart test` | 468件成功 |
| E2E | 6スイートをスキップ（実サーバー環境が必要） |
| `build_runner` | 生成物を更新済み・コミットに含む |

Refs #31
