### PR TITLE
1.0.0-beta.5 のバージョン対応

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.5] - 2026-08-14
+
 ### Removed
 
 - Removed `MisskeyCustomEmoji.roleIdsThatCanNotBeUsedThisEmojiAsReaction`, a breaking API change, because the field does not exist in upstream Misskey and is specific to the misskey.io fork

--- a/README.de.md
+++ b/README.de.md
@@ -22,7 +22,7 @@ Fügen Sie das Paket zu Ihrer `pubspec.yaml` hinzu:
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.4
+  misskey_client: ^1.0.0-beta.5
 ```
 
 Führen Sie anschließend aus:

--- a/README.fr.md
+++ b/README.fr.md
@@ -22,7 +22,7 @@ Ajoutez le package à votre `pubspec.yaml` :
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.4
+  misskey_client: ^1.0.0-beta.5
 ```
 
 Puis exécutez :

--- a/README.ja.md
+++ b/README.ja.md
@@ -21,7 +21,7 @@
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.4
+  misskey_client: ^1.0.0-beta.5
 ```
 
 その後、以下を実行します：

--- a/README.ko.md
+++ b/README.ko.md
@@ -22,7 +22,7 @@
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.4
+  misskey_client: ^1.0.0-beta.5
 ```
 
 그런 다음 실행합니다:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add the package to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.4
+  misskey_client: ^1.0.0-beta.5
 ```
 
 Then run:

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -22,7 +22,7 @@
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.4
+  misskey_client: ^1.0.0-beta.5
 ```
 
 然后运行：

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -23,7 +23,7 @@ Add the dependency to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.4
+  misskey_client: ^1.0.0-beta.5
 ```
 
 Then fetch it:

--- a/docs/i18n/de/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/de/docusaurus-plugin-content-docs/current/getting-started.md
@@ -23,7 +23,7 @@ Fuegen Sie die Abhaengigkeit in Ihre `pubspec.yaml` ein:
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.4
+  misskey_client: ^1.0.0-beta.5
 ```
 
 Anschliessend laden Sie das Paket herunter:

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/getting-started.md
@@ -23,7 +23,7 @@ Ajoutez la dépendance à votre `pubspec.yaml` :
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.4
+  misskey_client: ^1.0.0-beta.5
 ```
 
 Puis récupérez-la :

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/getting-started.md
@@ -19,7 +19,7 @@ slug: /
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.4
+  misskey_client: ^1.0.0-beta.5
 ```
 
 その後、依存関係を取得します。

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started.md
@@ -23,7 +23,7 @@ Flutter, 서버 사이드 Dart, CLI 도구 등 Dart가 실행되는 모든 환�
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.4
+  misskey_client: ^1.0.0-beta.5
 ```
 
 그 다음 패키지를 가져옵니다:

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started.md
@@ -23,7 +23,7 @@ misskey_client 是一个纯 Dart 编写的 Misskey API 客户端库。
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.4
+  misskey_client: ^1.0.0-beta.5
 ```
 
 然后获取依赖：

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: misskey_client
-version: 1.0.0-beta.4
+version: 1.0.0-beta.5
 documentation: https://librarylibrarian.github.io/misskey_client/
 environment:
   sdk: ">=3.9.0 <4.0.0"


### PR DESCRIPTION
## 概要

`1.0.0-beta.5` のリリース準備。バージョン参照を一括更新する。

`dart run tool/bump_version.dart 1.0.0-beta.5` による自動更新のみで、実装の変更は含まない。

## 収録内容

`1.0.0-beta.5` に含まれるのは以下の1件のみ。

- `MisskeyCustomEmoji.roleIdsThatCanNotBeUsedThisEmojiAsReaction` の削除（#43）

本家 Misskey に存在せず misskey.io フォーク専用のフィールドであったため削除した。**公開済み API からの破壊的削除**にあたる。

## 更新ファイル

- `pubspec.yaml` — version
- `CHANGELOG.md` — `[1.0.0-beta.5] - 2026-08-14` の見出しを追加
- README 6言語 — インストール例のバージョン
- docs 6言語（getting-started） — インストール例のバージョン

## 検証

| 項目 | 結果 |
|---|---|
| `dart run tool/verify_release.dart 1.0.0-beta.5` | consistent |
| `dart analyze` | No issues found |
| `dart format --set-exit-if-changed` | 287ファイル、差分なし |
| `dart test` | 468件成功 |

## 公開後の予定

このリリースにより、下流の `misskey_emoji` が deny フィールドを含まないバージョンに依存できるようになる。[misskey_emoji#2](https://github.com/LibraryLibrarian/misskey_emoji/pull/2) の依存指定を `^1.0.0-beta.5` に更新してからマージする。