### PR TITLE
MisskeyClient に baseUrl ゲッターを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `MisskeyClient.baseUrl`, exposing the configured server URL so that packages built on top of a client can identify which server it targets
+
 ## [1.0.0-beta.5] - 2026-08-14
 
 ### Removed

--- a/lib/src/client/misskey_client.dart
+++ b/lib/src/client/misskey_client.dart
@@ -109,6 +109,14 @@ class MisskeyClient {
   @internal
   final MisskeyHttp http;
 
+  /// The base URL of the Misskey server this client connects to.
+  ///
+  /// Returns the URL passed as [MisskeyClientConfig.baseUrl] as-is, without
+  /// the `/api` suffix that is appended internally. Useful for packages built
+  /// on top of a [MisskeyClient] that need to identify which server it
+  /// targets, for example to scope a per-server cache.
+  Uri get baseUrl => http.baseUrl;
+
   /// Account and profile management API.
   late final AccountApi account;
 

--- a/test/misskey_client_test.dart
+++ b/test/misskey_client_test.dart
@@ -10,4 +10,44 @@ void main() {
     );
     expect(client, isNotNull);
   });
+
+  group('baseUrl', () {
+    test('returns the configured base URL as-is', () {
+      final client = MisskeyClient(
+        config: MisskeyClientConfig(
+          baseUrl: Uri.parse('https://misskey.example.com'),
+        ),
+      );
+      expect(client.baseUrl, Uri.parse('https://misskey.example.com'));
+    });
+
+    test('does not append the internal /api suffix', () {
+      final client = MisskeyClient(
+        config: MisskeyClientConfig(
+          baseUrl: Uri.parse('https://misskey.example.com'),
+        ),
+      );
+      expect(client.baseUrl.path, isNot(contains('/api')));
+    });
+
+    test('preserves a port and a sub path', () {
+      final client = MisskeyClient(
+        config: MisskeyClientConfig(
+          baseUrl: Uri.parse('http://localhost:3000/instance'),
+        ),
+      );
+      expect(client.baseUrl, Uri.parse('http://localhost:3000/instance'));
+      expect(client.baseUrl.port, 3000);
+    });
+
+    test('keeps a base URL that already ends with /api unchanged', () {
+      // 利用側が /api 付きのURLを渡した場合も、受け取った値をそのまま返す
+      final client = MisskeyClient(
+        config: MisskeyClientConfig(
+          baseUrl: Uri.parse('https://misskey.example.com/api'),
+        ),
+      );
+      expect(client.baseUrl, Uri.parse('https://misskey.example.com/api'));
+    });
+  });
 }


### PR DESCRIPTION
## 概要

`MisskeyClient` に `Uri get baseUrl` を追加し、接続先サーバーを外部から識別できるようにする。

**非破壊的な追加。**

Closes #46

## 背景

`MisskeyClient` はコンストラクタで `MisskeyClientConfig` を受け取るが public フィールドとして保持しておらず、接続先の URL を知る手段が無かった。

値自体は内部に存在する（`MisskeyHttp.baseUrl`、`misskey_http.dart:53`）が、#38 で `MisskeyClient.http` に `@internal` を付与し（#31 の判断1 = 低レベル HTTP を公開 API に含めない）、`MisskeyHttp` 型も export していないため外部から到達できない状態だった。

判断1自体は妥当なので覆さず、**必要な情報だけを型安全な形で個別に公開する**方針で対応する。公開されるのは `Uri` 1つで、内部型は漏れない。

## 実装

```dart
/// The base URL of the Misskey server this client connects to.
///
/// Returns the URL passed as [MisskeyClientConfig.baseUrl] as-is, without
/// the `/api` suffix that is appended internally. Useful for packages built
/// on top of a [MisskeyClient] that need to identify which server it
/// targets, for example to scope a per-server cache.
Uri get baseUrl => http.baseUrl;
```

`baseUrl` のみを公開し、`MisskeyClientConfig` 全体は公開しない（#46 の案A）。現時点で判明している需要は `baseUrl` だけであり、API 表面を小さく保つという #31 の判断と整合するため。

## 解決される問題

[misskey_mfm_renderer#26](https://github.com/LibraryLibrarian/misskey_mfm_renderer/pull/26) の絵文字設定ヘルパーが `client` と `serverUrl` の**両方**を要求する冗長な形になっている。

```dart
MfmEmojiConfig.quickSetup(
  client: client,                      // 接続に使う
  serverUrl: 'https://misskey.io',     // Isar DB をサーバーごとに分離する識別子
);
```

`serverUrl` は本来 `client` から導出できる情報であり、現状は**両者が食い違う値を渡せてしまう**。A サーバーの `client` と B サーバーの `serverUrl` を渡すと、A から取得した絵文字を B 用のキャッシュに書き込む不整合が起きるが、型では防げない。

本PRの公開後、下流で `serverUrl` を廃止できる。`misskey_emoji` の `openEmojiIsarForServer(Uri baseUrl, ...)` は既に `Uri` を受け取る形なので、`client.baseUrl` をそのまま渡せる。

## 検証

| 項目 | 結果 |
|---|---|
| `dart analyze` | No issues found |
| `dart format --set-exit-if-changed` | 287ファイル、差分なし |
| `dart test` | **472件成功**（baseUrl のテスト4件を追加） |

追加したテストは以下の4ケース。

- 設定した URL がそのまま返ること
- 内部で付与される `/api` が含まれないこと
- ポートとサブパスが保持されること
- 利用側が `/api` 付きの URL を渡した場合もそのまま返すこと

## 影響

非破壊的な追加のため既存利用者への影響はない。

下流が利用するには新しいバージョンの公開が必要になる。`misskey_emoji` 2.0.0-beta.1 の公開前に取り込むことで、下流が一貫したバージョンを参照できる。