### PR TITLE
1.0.0-beta.6 を main へ反映

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.6] - 2026-08-14
+
 ### Added
 
 - Added `MisskeyClient.baseUrl`, exposing the configured server URL so that packages built on top of a client can identify which server it targets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `MisskeyClient.baseUrl`, exposing the configured server URL so that packages built on top of a client can identify which server it targets
+
 ## [1.0.0-beta.5] - 2026-08-14
 
 ### Removed

--- a/README.de.md
+++ b/README.de.md
@@ -22,7 +22,7 @@ Fügen Sie das Paket zu Ihrer `pubspec.yaml` hinzu:
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.5
+  misskey_client: ^1.0.0-beta.6
 ```
 
 Führen Sie anschließend aus:

--- a/README.fr.md
+++ b/README.fr.md
@@ -22,7 +22,7 @@ Ajoutez le package à votre `pubspec.yaml` :
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.5
+  misskey_client: ^1.0.0-beta.6
 ```
 
 Puis exécutez :

--- a/README.ja.md
+++ b/README.ja.md
@@ -21,7 +21,7 @@
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.5
+  misskey_client: ^1.0.0-beta.6
 ```
 
 その後、以下を実行します：

--- a/README.ko.md
+++ b/README.ko.md
@@ -22,7 +22,7 @@
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.5
+  misskey_client: ^1.0.0-beta.6
 ```
 
 그런 다음 실행합니다:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add the package to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.5
+  misskey_client: ^1.0.0-beta.6
 ```
 
 Then run:

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -22,7 +22,7 @@
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.5
+  misskey_client: ^1.0.0-beta.6
 ```
 
 然后运行：

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -23,7 +23,7 @@ Add the dependency to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.5
+  misskey_client: ^1.0.0-beta.6
 ```
 
 Then fetch it:

--- a/docs/i18n/de/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/de/docusaurus-plugin-content-docs/current/getting-started.md
@@ -23,7 +23,7 @@ Fuegen Sie die Abhaengigkeit in Ihre `pubspec.yaml` ein:
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.5
+  misskey_client: ^1.0.0-beta.6
 ```
 
 Anschliessend laden Sie das Paket herunter:

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/getting-started.md
@@ -23,7 +23,7 @@ Ajoutez la dépendance à votre `pubspec.yaml` :
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.5
+  misskey_client: ^1.0.0-beta.6
 ```
 
 Puis récupérez-la :

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/getting-started.md
@@ -19,7 +19,7 @@ slug: /
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.5
+  misskey_client: ^1.0.0-beta.6
 ```
 
 その後、依存関係を取得します。

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started.md
@@ -23,7 +23,7 @@ Flutter, 서버 사이드 Dart, CLI 도구 등 Dart가 실행되는 모든 환�
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.5
+  misskey_client: ^1.0.0-beta.6
 ```
 
 그 다음 패키지를 가져옵니다:

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started.md
@@ -23,7 +23,7 @@ misskey_client 是一个纯 Dart 编写的 Misskey API 客户端库。
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.5
+  misskey_client: ^1.0.0-beta.6
 ```
 
 然后获取依赖：

--- a/lib/src/client/misskey_client.dart
+++ b/lib/src/client/misskey_client.dart
@@ -109,6 +109,14 @@ class MisskeyClient {
   @internal
   final MisskeyHttp http;
 
+  /// The base URL of the Misskey server this client connects to.
+  ///
+  /// Returns the URL passed as [MisskeyClientConfig.baseUrl] as-is, without
+  /// the `/api` suffix that is appended internally. Useful for packages built
+  /// on top of a [MisskeyClient] that need to identify which server it
+  /// targets, for example to scope a per-server cache.
+  Uri get baseUrl => http.baseUrl;
+
   /// Account and profile management API.
   late final AccountApi account;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: misskey_client
-version: 1.0.0-beta.5
+version: 1.0.0-beta.6
 documentation: https://librarylibrarian.github.io/misskey_client/
 environment:
   sdk: ">=3.9.0 <4.0.0"

--- a/test/misskey_client_test.dart
+++ b/test/misskey_client_test.dart
@@ -10,4 +10,44 @@ void main() {
     );
     expect(client, isNotNull);
   });
+
+  group('baseUrl', () {
+    test('returns the configured base URL as-is', () {
+      final client = MisskeyClient(
+        config: MisskeyClientConfig(
+          baseUrl: Uri.parse('https://misskey.example.com'),
+        ),
+      );
+      expect(client.baseUrl, Uri.parse('https://misskey.example.com'));
+    });
+
+    test('does not append the internal /api suffix', () {
+      final client = MisskeyClient(
+        config: MisskeyClientConfig(
+          baseUrl: Uri.parse('https://misskey.example.com'),
+        ),
+      );
+      expect(client.baseUrl.path, isNot(contains('/api')));
+    });
+
+    test('preserves a port and a sub path', () {
+      final client = MisskeyClient(
+        config: MisskeyClientConfig(
+          baseUrl: Uri.parse('http://localhost:3000/instance'),
+        ),
+      );
+      expect(client.baseUrl, Uri.parse('http://localhost:3000/instance'));
+      expect(client.baseUrl.port, 3000);
+    });
+
+    test('keeps a base URL that already ends with /api unchanged', () {
+      // 利用側が /api 付きのURLを渡した場合も、受け取った値をそのまま返す
+      final client = MisskeyClient(
+        config: MisskeyClientConfig(
+          baseUrl: Uri.parse('https://misskey.example.com/api'),
+        ),
+      );
+      expect(client.baseUrl, Uri.parse('https://misskey.example.com/api'));
+    });
+  });
 }


### PR DESCRIPTION
## 概要

`1.0.0-beta.6` のリリース準備。バージョン参照を一括更新する。

`dart run tool/bump_version.dart 1.0.0-beta.6` による自動更新のみで、実装の変更は含まない。

## 収録内容

`1.0.0-beta.6` に含まれるのは以下の1件のみ。

- `MisskeyClient.baseUrl` の追加（#47 / Closes #46）

拡張パッケージが接続先サーバーを識別できるようにする**非破壊的な追加**。

## 更新ファイル

- `pubspec.yaml` — version
- `CHANGELOG.md` — `[1.0.0-beta.6] - 2026-08-14` の見出しを追加
- README 6言語 — インストール例のバージョン
- docs 6言語（getting-started） — インストール例のバージョン

## 検証

| 項目 | 結果 |
|---|---|
| `dart run tool/verify_release.dart 1.0.0-beta.6` | consistent |
| `dart analyze` | No issues found |
| `dart format --set-exit-if-changed` | 287ファイル、差分なし |
| `dart test` | 472件成功 |

## 公開後の予定

このリリースにより、下流が `client.baseUrl` を参照できるようになる。

- `misskey_emoji` — 依存を `^1.0.0-beta.6` に更新してから `2.0.0-beta.1` を公開
- `misskey_mfm_renderer` — [PR #26](https://github.com/LibraryLibrarian/misskey_mfm_renderer/pull/26) から冗長な `serverUrl` 引数を削除できる。**同PRはまだマージしていないため、冗長なAPIを公開せずに済む**

---

## マージ後の作業

`v1.0.0-beta.6` タグを作成・push すると `publish.yml` が起動し、以下が自動実行される。

1. `verify_release.dart` によるバージョン整合の検証
2. pub.dev への公開（OIDC）
3. GitHub Release の作成（プレリリースのため `--prerelease --latest=false`）

**このPRと develop 向けPRの両方をマージしてから**タグを打つこと。
