### PR TITLE
1.0.0-beta.7 のバージョン対応

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.7] - 2026-08-16
+
 ### Added
 
 - Integrated Misskey Streaming API access through the lazily created `MisskeyClient.streaming` property, sharing the client's base URL, token provider, logger, and log setting (issue #30)

--- a/README.de.md
+++ b/README.de.md
@@ -23,7 +23,7 @@ Fügen Sie das Paket zu Ihrer `pubspec.yaml` hinzu:
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.6
+  misskey_client: ^1.0.0-beta.7
 ```
 
 Führen Sie anschließend aus:

--- a/README.fr.md
+++ b/README.fr.md
@@ -23,7 +23,7 @@ Ajoutez le package à votre `pubspec.yaml` :
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.6
+  misskey_client: ^1.0.0-beta.7
 ```
 
 Puis exécutez :

--- a/README.ja.md
+++ b/README.ja.md
@@ -22,7 +22,7 @@
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.6
+  misskey_client: ^1.0.0-beta.7
 ```
 
 その後、以下を実行します：

--- a/README.ko.md
+++ b/README.ko.md
@@ -23,7 +23,7 @@
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.6
+  misskey_client: ^1.0.0-beta.7
 ```
 
 그런 다음 실행합니다:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add the package to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.6
+  misskey_client: ^1.0.0-beta.7
 ```
 
 Then run:

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -23,7 +23,7 @@
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.6
+  misskey_client: ^1.0.0-beta.7
 ```
 
 然后运行：

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -23,7 +23,7 @@ Add the dependency to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.6
+  misskey_client: ^1.0.0-beta.7
 ```
 
 Then fetch it:

--- a/docs/i18n/de/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/de/docusaurus-plugin-content-docs/current/getting-started.md
@@ -23,7 +23,7 @@ Fuegen Sie die Abhaengigkeit in Ihre `pubspec.yaml` ein:
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.6
+  misskey_client: ^1.0.0-beta.7
 ```
 
 Anschliessend laden Sie das Paket herunter:

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/getting-started.md
@@ -23,7 +23,7 @@ Ajoutez la dépendance à votre `pubspec.yaml` :
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.6
+  misskey_client: ^1.0.0-beta.7
 ```
 
 Puis récupérez-la :

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/getting-started.md
@@ -19,7 +19,7 @@ slug: /
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.6
+  misskey_client: ^1.0.0-beta.7
 ```
 
 その後、依存関係を取得します。

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started.md
@@ -23,7 +23,7 @@ Flutter, 서버 사이드 Dart, CLI 도구 등 Dart가 실행되는 모든 환�
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.6
+  misskey_client: ^1.0.0-beta.7
 ```
 
 그 다음 패키지를 가져옵니다:

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started.md
@@ -23,7 +23,7 @@ misskey_client 是一个纯 Dart 编写的 Misskey API 客户端库。
 
 ```yaml
 dependencies:
-  misskey_client: ^1.0.0-beta.6
+  misskey_client: ^1.0.0-beta.7
 ```
 
 然后获取依赖：

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: misskey_client
-version: 1.0.0-beta.6
+version: 1.0.0-beta.7
 documentation: https://librarylibrarian.github.io/misskey_client/
 environment:
   sdk: ">=3.9.0 <4.0.0"


### PR DESCRIPTION
## 概要

`1.0.0-beta.7` のリリース準備。バージョン参照を一括更新する。

`dart run tool/bump_version.dart 1.0.0-beta.7` による自動更新のみで、実装の変更は含まない。

## 収録内容

`1.0.0-beta.7` に含まれるのは以下の1件。

- Streaming API (WebSocket) の統合（#50 / Closes #30）

`MisskeyClient.streaming` の追加による**非破壊的な追加**。既存APIの変更は `MisskeyClient.dispose()` が初期化済み Streaming 接続を先に破棄するようになった点のみで、呼び出し側の変更は不要。

別パッケージ `misskey_streaming` の機能を取り込んだもので、接続ライフサイクル、公式18チャンネルの型付き購読、型付きイベント配信、note capture、6言語の文書と移行ガイドを含む。

## 更新ファイル

- `pubspec.yaml` — version
- `CHANGELOG.md` — `[1.0.0-beta.7] - 2026-08-16` の見出しを追加
- README 6言語 — インストール例のバージョン
- docs 6言語（getting-started） — インストール例のバージョン

## 検証

| 項目 | 結果 |
|---|---|
| `dart run tool/verify_release.dart 1.0.0-beta.7` | consistent |
| `dart analyze` | No issues found |
| `dart format --set-exit-if-changed` | 309ファイル、差分なし |
| `dart test` | 548件成功（E2E 7件 skip） |

## 公開後の予定

pub.dev 公開後、#30 記載の順序で `misskey_streaming` の非推奨化を実施する。

1. README 冒頭へ非推奨と移行先を追加
2. migration guide へリンクした最終版を公開
3. pub.dev で Discontinued を設定し `misskey_client` を replacement に指定
4. GitHub リポジトリを archive
