### PR TITLE
fix: mutedWords/hardMutedWordsを型安全なunionでパース (#53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking:** Replaced the dynamic and nested-list word-mute APIs with the type-safe `MutedWordKeywords` / `MutedWordRegex` sealed union across authenticated-user reads, admin user details, and `AccountApi.update()`, with `MutedWordUnknown` preserving unrecognized fork-specific values instead of failing the entire response (issue #53)
+
 ## [1.0.0-beta.7] - 2026-08-16
 
 ### Added

--- a/lib/misskey_client.dart
+++ b/lib/misskey_client.dart
@@ -126,6 +126,7 @@ export 'src/models/misskey_renote_muting.dart';
 export 'src/models/misskey_role.dart';
 export 'src/models/misskey_role_user.dart';
 export 'src/models/misskey_user.dart';
+export 'src/models/muted_word.dart';
 export 'src/models/server/avatar_decoration.dart';
 export 'src/models/server/emoji_detailed.dart';
 export 'src/models/server/endpoint_info.dart';

--- a/lib/src/api/account/account_api.dart
+++ b/lib/src/api/account/account_api.dart
@@ -7,8 +7,10 @@ import '../../internal/request_body.dart';
 import '../../models/account/misskey_signin_history.dart';
 import '../../models/gallery/misskey_gallery_like.dart';
 import '../../models/gallery/misskey_gallery_post.dart';
+import '../../models/json_converters.dart';
 import '../../models/misskey_note_favorite.dart';
 import '../../models/misskey_user.dart';
+import '../../models/muted_word.dart';
 import 'registry_api.dart';
 import 'two_factor_api.dart';
 import 'webhooks_api.dart';
@@ -88,9 +90,11 @@ class AccountApi {
   /// Unix timestamp (ms) followers-only. [makeNotesHiddenBefore] hides notes
   /// before that timestamp. [pinnedPageId] pins the specified page ID.
   ///
-  /// [mutedWords] is a list where each element is either an AND-condition
-  /// string list or a regex string. [hardMutedWords] works similarly for
-  /// hard mutes. [mutedInstances] is a list of hostnames to mute.
+  /// [mutedWords] accepts [MutedWordKeywords] AND-condition groups and
+  /// [MutedWordRegex] patterns. [hardMutedWords] works similarly for hard
+  /// mutes. A [MutedWordUnknown] read from a fork can be passed through, but
+  /// upstream Misskey may reject its unrecognized shape. [mutedInstances] is
+  /// a list of hostnames to mute.
   /// [alsoKnownAs] holds URIs of alternate accounts (migration source,
   /// up to 10). [followedMessage] sets the message shown when followed
   /// (use `Optional.null_()` to clear it).
@@ -136,8 +140,8 @@ class AccountApi {
     Optional<int>? makeNotesFollowersOnlyBefore,
     Optional<int>? makeNotesHiddenBefore,
     Optional<String>? pinnedPageId,
-    List<dynamic>? mutedWords,
-    List<dynamic>? hardMutedWords,
+    List<MutedWord>? mutedWords,
+    List<MutedWord>? hardMutedWords,
     List<String>? mutedInstances,
     Map<String, Map<String, dynamic>>? notificationRecieveConfig,
     List<String>? emailNotificationTypes,
@@ -195,8 +199,14 @@ class AccountApi {
     );
     putOptional(body, 'makeNotesHiddenBefore', makeNotesHiddenBefore);
     putOptional(body, 'pinnedPageId', pinnedPageId);
-    if (mutedWords != null) body['mutedWords'] = mutedWords;
-    if (hardMutedWords != null) body['hardMutedWords'] = hardMutedWords;
+    if (mutedWords != null) {
+      body['mutedWords'] = const MutedWordListConverter().toJson(mutedWords);
+    }
+    if (hardMutedWords != null) {
+      body['hardMutedWords'] = const MutedWordListConverter().toJson(
+        hardMutedWords,
+      );
+    }
     if (mutedInstances != null) body['mutedInstances'] = mutedInstances;
     if (notificationRecieveConfig != null) {
       body['notificationRecieveConfig'] = notificationRecieveConfig;

--- a/lib/src/models/admin/misskey_admin_user_detail.dart
+++ b/lib/src/models/admin/misskey_admin_user_detail.dart
@@ -2,6 +2,7 @@ import 'package:json_annotation/json_annotation.dart';
 
 import '../json_converters.dart';
 import '../misskey_role.dart';
+import '../muted_word.dart';
 
 part 'misskey_admin_user_detail.g.dart';
 
@@ -76,8 +77,9 @@ class MisskeyAdminUserDetail {
   /// Whether announcement emails are received.
   final bool? receiveAnnouncementEmail;
 
-  /// Muted word patterns (each entry is a string or a list of strings).
-  final List<dynamic>? mutedWords;
+  /// The word-mute conditions, each represented by keywords or a regex.
+  @MutedWordListConverter()
+  final List<MutedWord>? mutedWords;
 
   /// Muted instance hosts.
   final List<String>? mutedInstances;

--- a/lib/src/models/admin/misskey_admin_user_detail.g.dart
+++ b/lib/src/models/admin/misskey_admin_user_detail.g.dart
@@ -20,7 +20,9 @@ MisskeyAdminUserDetail _$MisskeyAdminUserDetailFromJson(
   carefulBot: json['carefulBot'] as bool?,
   injectFeaturedNote: json['injectFeaturedNote'] as bool?,
   receiveAnnouncementEmail: json['receiveAnnouncementEmail'] as bool?,
-  mutedWords: json['mutedWords'] as List<dynamic>?,
+  mutedWords: const MutedWordListConverter().fromJson(
+    json['mutedWords'] as List?,
+  ),
   mutedInstances: (json['mutedInstances'] as List<dynamic>?)
       ?.map((e) => e as String)
       .toList(),
@@ -60,7 +62,7 @@ Map<String, dynamic> _$MisskeyAdminUserDetailToJson(
   'carefulBot': instance.carefulBot,
   'injectFeaturedNote': instance.injectFeaturedNote,
   'receiveAnnouncementEmail': instance.receiveAnnouncementEmail,
-  'mutedWords': instance.mutedWords,
+  'mutedWords': const MutedWordListConverter().toJson(instance.mutedWords),
   'mutedInstances': instance.mutedInstances,
   'notificationRecieveConfig': instance.notificationRecieveConfig,
   'isModerator': instance.isModerator,

--- a/lib/src/models/json_converters.dart
+++ b/lib/src/models/json_converters.dart
@@ -1,5 +1,7 @@
 import 'package:json_annotation/json_annotation.dart';
 
+import 'muted_word.dart';
+
 /// A safe [JsonConverter] that uses [DateTime.tryParse].
 ///
 /// Falls back to `null` instead of throwing on malformed input.
@@ -12,4 +14,43 @@ class SafeDateTimeConverter implements JsonConverter<DateTime?, String?> {
 
   @override
   String? toJson(DateTime? object) => object?.toIso8601String();
+}
+
+/// Converts Misskey word-mute conditions to and from their JSON union shape.
+///
+/// Unrecognized element shapes are preserved as [MutedWordUnknown] so that a
+/// fork-specific value does not make the entire user response unusable.
+class MutedWordListConverter
+    implements JsonConverter<List<MutedWord>?, List<dynamic>?> {
+  const MutedWordListConverter();
+
+  @override
+  List<MutedWord>? fromJson(List<dynamic>? json) {
+    if (json == null) return null;
+
+    return json.map(_fromJsonElement).toList();
+  }
+
+  @override
+  List<dynamic>? toJson(List<MutedWord>? object) => object
+      ?.map<dynamic>(
+        (word) => switch (word) {
+          MutedWordKeywords(:final keywords) => keywords,
+          MutedWordRegex(:final pattern) => pattern,
+          MutedWordUnknown(:final rawValue) => rawValue,
+        },
+      )
+      .toList();
+
+  MutedWord _fromJsonElement(dynamic value) {
+    if (value is String) {
+      return MutedWordRegex(pattern: value);
+    }
+    if (value is List<dynamic>) {
+      if (value.every((element) => element is String)) {
+        return MutedWordKeywords(keywords: value.cast<String>());
+      }
+    }
+    return MutedWordUnknown(rawValue: value);
+  }
 }

--- a/lib/src/models/misskey_user.dart
+++ b/lib/src/models/misskey_user.dart
@@ -2,6 +2,7 @@ import 'package:json_annotation/json_annotation.dart';
 
 import 'json_converters.dart';
 import 'misskey_note.dart';
+import 'muted_word.dart';
 
 part 'misskey_user.g.dart';
 
@@ -429,13 +430,13 @@ class MisskeyUser {
   @JsonKey(defaultValue: 0)
   final int? unreadNotificationsCount;
 
-  /// The list of muted word groups. Each group is a list of keywords
-  /// (AND condition).
-  final List<List<String>>? mutedWords;
+  /// The word-mute conditions, each represented by keywords or a regex.
+  @MutedWordListConverter()
+  final List<MutedWord>? mutedWords;
 
-  /// The list of hard-muted word groups. Each group is a list of keywords
-  /// (AND condition).
-  final List<List<String>>? hardMutedWords;
+  /// The hard word-mute conditions, each represented by keywords or a regex.
+  @MutedWordListConverter()
+  final List<MutedWord>? hardMutedWords;
 
   /// The list of muted instance hostnames.
   final List<String>? mutedInstances;

--- a/lib/src/models/misskey_user.g.dart
+++ b/lib/src/models/misskey_user.g.dart
@@ -131,12 +131,12 @@ MisskeyUser _$MisskeyUserFromJson(Map<String, dynamic> json) => MisskeyUser(
       json['hasPendingReceivedFollowRequest'] as bool? ?? false,
   unreadNotificationsCount:
       (json['unreadNotificationsCount'] as num?)?.toInt() ?? 0,
-  mutedWords: (json['mutedWords'] as List<dynamic>?)
-      ?.map((e) => (e as List<dynamic>).map((e) => e as String).toList())
-      .toList(),
-  hardMutedWords: (json['hardMutedWords'] as List<dynamic>?)
-      ?.map((e) => (e as List<dynamic>).map((e) => e as String).toList())
-      .toList(),
+  mutedWords: const MutedWordListConverter().fromJson(
+    json['mutedWords'] as List?,
+  ),
+  hardMutedWords: const MutedWordListConverter().fromJson(
+    json['hardMutedWords'] as List?,
+  ),
   mutedInstances: (json['mutedInstances'] as List<dynamic>?)
       ?.map((e) => e as String)
       .toList(),
@@ -254,8 +254,10 @@ Map<String, dynamic> _$MisskeyUserToJson(
   'hasUnreadNotification': instance.hasUnreadNotification,
   'hasPendingReceivedFollowRequest': instance.hasPendingReceivedFollowRequest,
   'unreadNotificationsCount': instance.unreadNotificationsCount,
-  'mutedWords': instance.mutedWords,
-  'hardMutedWords': instance.hardMutedWords,
+  'mutedWords': const MutedWordListConverter().toJson(instance.mutedWords),
+  'hardMutedWords': const MutedWordListConverter().toJson(
+    instance.hardMutedWords,
+  ),
   'mutedInstances': instance.mutedInstances,
   'mutingNotificationTypes': instance.mutingNotificationTypes,
   'notificationRecieveConfig': instance.notificationRecieveConfig,

--- a/lib/src/models/muted_word.dart
+++ b/lib/src/models/muted_word.dart
@@ -1,0 +1,36 @@
+/// A word-mute condition accepted by Misskey.
+///
+/// Use [MutedWordKeywords] for an AND-condition keyword group or
+/// [MutedWordRegex] for a regular expression. [MutedWordUnknown] preserves an
+/// unrecognized JSON shape returned by a fork or a newer server.
+sealed class MutedWord {
+  const MutedWord();
+}
+
+/// A word-mute condition that matches all of the specified [keywords].
+final class MutedWordKeywords extends MutedWord {
+  const MutedWordKeywords({required this.keywords});
+
+  /// The keywords combined as an AND condition.
+  final List<String> keywords;
+}
+
+/// A word-mute condition represented by a regular expression.
+final class MutedWordRegex extends MutedWord {
+  const MutedWordRegex({required this.pattern});
+
+  /// The regular expression in the raw Misskey API format.
+  final String pattern;
+}
+
+/// An unrecognized word-mute condition returned by the server.
+///
+/// This fallback keeps authenticated-user responses usable when a fork or a
+/// newer Misskey version adds another condition shape. The raw value is
+/// preserved when the model is converted back to JSON.
+final class MutedWordUnknown extends MutedWord {
+  const MutedWordUnknown({required this.rawValue});
+
+  /// The unrecognized JSON value as returned by the server.
+  final Object? rawValue;
+}

--- a/test/api/account_api_test.dart
+++ b/test/api/account_api_test.dart
@@ -1,0 +1,133 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:misskey_client/misskey_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('AccountApi.update', () {
+    test(
+      'sends word-mute conditions in the Misskey JSON union shape',
+      () async {
+        final adapter = _RecordingHttpClientAdapter();
+        final client = MisskeyClient(
+          config: MisskeyClientConfig(
+            baseUrl: Uri.parse('https://misskey.example.com'),
+          ),
+          httpClientAdapter: adapter,
+        );
+        addTearDown(client.dispose);
+
+        await client.account.update(
+          mutedWords: const [
+            MutedWordKeywords(keywords: ['misskey', 'client']),
+            MutedWordRegex(pattern: '/spam/i'),
+          ],
+          hardMutedWords: const [
+            MutedWordRegex(pattern: '/spoiler/i'),
+            MutedWordKeywords(keywords: ['hard', 'mute']),
+          ],
+        );
+
+        expect(adapter.path, '/api/i/update');
+        expect(adapter.body, {
+          'mutedWords': [
+            ['misskey', 'client'],
+            '/spam/i',
+          ],
+          'hardMutedWords': [
+            '/spoiler/i',
+            ['hard', 'mute'],
+          ],
+        });
+      },
+    );
+
+    test('preserves empty word-mute values in the request body', () async {
+      final adapter = _RecordingHttpClientAdapter();
+      final client = MisskeyClient(
+        config: MisskeyClientConfig(
+          baseUrl: Uri.parse('https://misskey.example.com'),
+        ),
+        httpClientAdapter: adapter,
+      );
+      addTearDown(client.dispose);
+
+      await client.account.update(
+        mutedWords: const [],
+        hardMutedWords: const [
+          MutedWordKeywords(keywords: []),
+          MutedWordKeywords(keywords: ['']),
+          MutedWordRegex(pattern: ''),
+        ],
+      );
+
+      expect(adapter.body, {
+        'mutedWords': <dynamic>[],
+        'hardMutedWords': [
+          <String>[],
+          [''],
+          '',
+        ],
+      });
+    });
+  });
+
+  group('AccountApi.i', () {
+    test('parses mixed word-mute conditions from the API response', () async {
+      final response =
+          jsonDecode(File('test/fixtures/i.json').readAsStringSync())
+              as Map<String, dynamic>;
+      final adapter = _RecordingHttpClientAdapter(response: response);
+      final client = MisskeyClient(
+        config: MisskeyClientConfig(
+          baseUrl: Uri.parse('https://misskey.example.com'),
+        ),
+        httpClientAdapter: adapter,
+      );
+      addTearDown(client.dispose);
+
+      final user = await client.account.i();
+
+      expect(adapter.path, '/api/i');
+      expect(user.mutedWords, [
+        isA<MutedWordKeywords>(),
+        isA<MutedWordRegex>(),
+      ]);
+      expect(user.hardMutedWords, [
+        isA<MutedWordRegex>(),
+        isA<MutedWordKeywords>(),
+      ]);
+    });
+  });
+}
+
+final class _RecordingHttpClientAdapter implements HttpClientAdapter {
+  _RecordingHttpClientAdapter({this.response});
+
+  final Map<String, dynamic>? response;
+  String? path;
+  Map<String, dynamic>? body;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    path = options.uri.path;
+    body = options.data as Map<String, dynamic>;
+    return ResponseBody.fromString(
+      jsonEncode(response ?? {'id': 'user-id', 'username': 'alice'}),
+      200,
+      headers: {
+        Headers.contentTypeHeader: ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}

--- a/test/fixtures/admin_show_user.json
+++ b/test/fixtures/admin_show_user.json
@@ -10,7 +10,10 @@
   "carefulBot": false,
   "injectFeaturedNote": true,
   "receiveAnnouncementEmail": true,
-  "mutedWords": [],
+  "mutedWords": [
+    ["misskey", "client"],
+    "/spam/i"
+  ],
   "mutedInstances": [],
   "notificationRecieveConfig": {},
   "isModerator": false,

--- a/test/fixtures/i.json
+++ b/test/fixtures/i.json
@@ -99,8 +99,14 @@
   "hasUnreadNotification": false,
   "hasPendingReceivedFollowRequest": false,
   "unreadNotificationsCount": 0,
-  "mutedWords": [],
-  "hardMutedWords": [],
+  "mutedWords": [
+    ["misskey", "client"],
+    "/spam/i"
+  ],
+  "hardMutedWords": [
+    "/spoiler/i",
+    ["hard", "mute"]
+  ],
   "mutedInstances": [],
   "mutingNotificationTypes": [],
   "notificationRecieveConfig": {},

--- a/test/models/misskey_admin_models_test.dart
+++ b/test/models/misskey_admin_models_test.dart
@@ -87,6 +87,30 @@ void main() {
       expect(signin.id, isNotEmpty);
       expect(signin.success, isTrue);
     });
+
+    test('round-trips mixed word-mute JSON shapes', () {
+      final json = load();
+      final detail = MisskeyAdminUserDetail.fromJson(json);
+
+      expect(
+        detail.mutedWords,
+        containsAllInOrder([
+          isA<MutedWordKeywords>().having((word) => word.keywords, 'keywords', [
+            'misskey',
+            'client',
+          ]),
+          isA<MutedWordRegex>().having(
+            (word) => word.pattern,
+            'pattern',
+            '/spam/i',
+          ),
+        ]),
+      );
+
+      final encoded = detail.toJson();
+      expect(encoded['mutedWords'], json['mutedWords']);
+      expect(MisskeyAdminUserDetail.fromJson(encoded).mutedWords, hasLength(2));
+    });
   });
 
   group('MisskeyAdminCreatedAccount.fromJson', () {

--- a/test/models/misskey_user_test.dart
+++ b/test/models/misskey_user_test.dart
@@ -226,13 +226,106 @@ void main() {
       expect(user.hasPendingReceivedFollowRequest, false);
     });
 
-    test('parses muting config from i', () {
+    test('parses mixed word-mute conditions from i', () {
       final file = File('test/fixtures/i.json');
       final json = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
       final user = MisskeyUser.fromJson(json);
 
-      expect(user.mutedWords, isEmpty);
+      expect(
+        user.mutedWords,
+        containsAllInOrder([
+          isA<MutedWordKeywords>().having((word) => word.keywords, 'keywords', [
+            'misskey',
+            'client',
+          ]),
+          isA<MutedWordRegex>().having(
+            (word) => word.pattern,
+            'pattern',
+            '/spam/i',
+          ),
+        ]),
+      );
+      expect(
+        user.hardMutedWords,
+        containsAllInOrder([
+          isA<MutedWordRegex>().having(
+            (word) => word.pattern,
+            'pattern',
+            '/spoiler/i',
+          ),
+          isA<MutedWordKeywords>().having((word) => word.keywords, 'keywords', [
+            'hard',
+            'mute',
+          ]),
+        ]),
+      );
       expect(user.mutedInstances, isEmpty);
+    });
+
+    test('round-trips mixed word-mute JSON shapes', () {
+      final file = File('test/fixtures/i.json');
+      final json = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+      final user = MisskeyUser.fromJson(json);
+
+      final encoded = user.toJson();
+      expect(encoded['mutedWords'], json['mutedWords']);
+      expect(encoded['hardMutedWords'], json['hardMutedWords']);
+
+      final reparsed = MisskeyUser.fromJson(encoded);
+      expect(reparsed.mutedWords, hasLength(2));
+      expect(reparsed.hardMutedWords, hasLength(2));
+    });
+
+    test('round-trips empty word-mute values without normalization', () {
+      final json =
+          jsonDecode(r'''
+        {
+          "id": "user-id",
+          "username": "alice",
+          "mutedWords": [[], [""], ""],
+          "hardMutedWords": []
+        }
+      ''')
+              as Map<String, dynamic>;
+      final user = MisskeyUser.fromJson(json);
+
+      expect(
+        user.mutedWords,
+        containsAllInOrder([
+          isA<MutedWordKeywords>().having(
+            (word) => word.keywords,
+            'keywords',
+            isEmpty,
+          ),
+          isA<MutedWordKeywords>().having((word) => word.keywords, 'keywords', [
+            '',
+          ]),
+          isA<MutedWordRegex>().having(
+            (word) => word.pattern,
+            'pattern',
+            isEmpty,
+          ),
+        ]),
+      );
+      expect(user.hardMutedWords, isEmpty);
+      expect(user.toJson()['mutedWords'], json['mutedWords']);
+      expect(user.toJson()['hardMutedWords'], json['hardMutedWords']);
+    });
+
+    test('preserves unrecognized word-mute element shapes', () {
+      final json =
+          jsonDecode(r'''
+        {
+          "id": "user-id",
+          "username": "alice",
+          "mutedWords": [42, ["valid", null], {"type": "fork"}, null]
+        }
+      ''')
+              as Map<String, dynamic>;
+      final user = MisskeyUser.fromJson(json);
+
+      expect(user.mutedWords, everyElement(isA<MutedWordUnknown>()));
+      expect(user.toJson()['mutedWords'], json['mutedWords']);
     });
 
     test('UserLite fields absent in notes/show default correctly', () {


### PR DESCRIPTION
## 概要

`mutedWords` / `hardMutedWords` は各要素が「AND 条件の文字列配列」または「正規表現の単一文字列」を取り得る union 型だが、読み込み側の `MisskeyUser` は `List<List<String>>?` 固定だった。そのため正規表現形式のミュートワードを 1 件でも設定しているアカウントでは、`AccountApi.i()` が `TypeError (type 'String' is not a subtype of type 'List<dynamic>')` で失敗していた。

`i()` は認証ユーザー情報全般を返す基幹エンドポイントのため、影響はミュート設定の読み取りに留まらない。

一方 `update()` はパラメータ型 `List<dynamic>?` で union を許容しており、読み書きで型が非対称だった。

Closes #53

## 変更内容

### `MutedWord` sealed union の追加

```dart
sealed class MutedWord
├── MutedWordKeywords  // AND 条件のキーワード群
├── MutedWordRegex     // 正規表現
└── MutedWordUnknown   // 未知の形状を生値のまま保持
```

`MutedWordListConverter` で JSON の union 形状との相互変換を行い、`toJson()` は元の形状（`List<String>` または `String`）を厳密に復元する。

### 型の統一（破壊的変更）

| 対象 | 変更前 | 変更後 |
|---|---|---|
| `MisskeyUser.mutedWords` / `hardMutedWords` | `List<List<String>>?` | `List<MutedWord>?` |
| `MisskeyAdminUserDetail.mutedWords` | `List<dynamic>?` | `List<MutedWord>?` |
| `AccountApi.update()` のパラメータ | `List<dynamic>?` | `List<MutedWord>?` |

読み込みと書き込みが同一の型を扱うようになり、issue が指摘した設計上の非対称性が型で解消された。

### 未知の形状の扱い

fork（misskey.io / Sharkey / CherryPick 等）や将来の Misskey が新しい条件形状を追加した場合、例外で `i()` 全体を失敗させるのではなく `MutedWordUnknown` として生値を保持する。ラウンドトリップで元の値を復元するため、未知要素を含むアカウントで設定を編集してもサーバ側の値を破壊しない。

### `admin/show-user` の `hardMutedWords` について

Misskey 公式 `develop` のレスポンススキーマと返却オブジェクトの双方が `mutedWords` のみを定義しており `hardMutedWords` を返していないことを確認したため、`MisskeyAdminUserDetail` への追加は行っていない。

## テスト

既存 fixture は `mutedWords` が全て空配列で、この不具合を検出できない状態だった。AND 条件と正規表現が混在する fixture に差し替えたうえで、以下を追加している。

- 混在形状のパース（`MisskeyUser` / `MisskeyAdminUserDetail`）
- `fromJson` / `toJson` のラウンドトリップ
- 未知形状の `MutedWordUnknown` へのフォールバックと生値の復元
- 空配列・空キーワード・空文字列の境界値
- `AccountApi.update()` が Misskey の JSON union 形状で送信すること
- `AccountApi.i()` の直接検証

## 検証

- `dart analyze`: 指摘 0 件
- `dart test`: 555 件成功（E2E 7 件は環境未設定のため skip）
- `dart format --output=none --set-exit-if-changed .`: 311 ファイル、変更 0
- `build_runner` 再生成による追加差分なし

## 影響範囲

`MisskeyUser` は `users/show`、`users/following`、`admin/show-users`、`frequent-users` 等のパースにも共通利用されているため、全経路で新しい converter が適用されることを確認済み。`mastodon_client` にはワードミュート相当のフィールドが存在せず（Mastodon は `MastodonFilterKeyword` という型付きオブジェクトで表現）、波及はない。
