### PR TITLE
feat: リリースフローを自動化

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,8 +12,15 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - uses: dart-lang/setup-dart@v1
+
+      - name: Verify tag commit is on main
+        run: |
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
 
       - name: Verify release version
         run: dart run tool/verify_release.dart "${GITHUB_REF_NAME#v}"
@@ -55,3 +62,54 @@ jobs:
             --title "$GITHUB_REF_NAME" \
             --notes-file "$RUNNER_TEMP/release-notes.md" \
             "${release_options[@]}"
+
+  merge-back:
+    needs: release
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v7
+        with:
+          ref: develop
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Merge main back into develop
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+
+          if git merge-base --is-ancestor origin/main HEAD; then
+            echo "develop already contains main. Nothing to do."
+            exit 0
+          fi
+
+          if git merge --no-ff -m "chore: merge back $GITHUB_REF_NAME into develop" origin/main \
+            && git push origin develop; then
+            echo "Merged main into develop."
+            exit 0
+          fi
+
+          # 競合、またはブランチ保護により直接pushできない場合のフォールバック
+          git merge --abort || true
+          branch="chore/merge-back-$GITHUB_REF_NAME"
+          git switch -c "$branch" origin/main
+          git push -u --force-with-lease origin "$branch"
+          gh pr create \
+            --base develop \
+            --head "$branch" \
+            --title "chore: merge back $GITHUB_REF_NAME into develop" \
+            --body "自動マージバックに失敗したため、手動での競合解決が必要。" \
+            || echo "既存のPRがあるため作成をスキップした。"
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'リリースするバージョン（例: 1.2.0 / 1.2.0-beta.1）'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v7
+        with:
+          ref: develop
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: dart-lang/setup-dart@v1
+
+      - name: Bump version
+        env:
+          TZ: Asia/Tokyo
+          VERSION: ${{ inputs.version }}
+        run: dart run tool/bump_version.dart "$VERSION"
+
+      - name: Create release branch
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git switch -c "release/$VERSION"
+          git commit -am "chore(release): $VERSION"
+          git push -u origin "release/$VERSION"
+
+      - name: Open pull request
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          gh pr create \
+            --base main \
+            --head "release/$VERSION" \
+            --title "release: $VERSION" \
+            --body "\`tool/bump_version.dart\` による自動生成。マージすると \`v$VERSION\` タグが作成され、pub.devへの公開とGitHub Release作成まで自動実行される。"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,43 @@
+name: Tag Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tag-release
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: dart-lang/setup-dart@v1
+
+      - name: Install dependencies
+        run: dart pub get
+
+      - name: Create tag if missing
+        run: |
+          version="$(dart run tool/print_version.dart)"
+          if git rev-parse -q --verify "refs/tags/v$version" >/dev/null; then
+            echo "Tag v$version already exists. Nothing to do."
+            exit 0
+          fi
+          git tag "v$version"
+          git push origin "v$version"

--- a/test/tool/release_project_test.dart
+++ b/test/tool/release_project_test.dart
@@ -16,6 +16,10 @@ void main() {
     root.deleteSync(recursive: true);
   });
 
+  test('readPubspecVersion returns the validated package version', () {
+    expect(readPubspecVersion(root), '1.0.0-beta.3');
+  });
+
   test('bumpVersion updates all version references and CHANGELOG', () {
     final updatedPaths = bumpVersion(
       root,

--- a/tool/print_version.dart
+++ b/tool/print_version.dart
@@ -1,0 +1,15 @@
+import 'dart:io';
+
+import 'src/release_project.dart';
+
+void main() {
+  try {
+    stdout.writeln(readPubspecVersion(Directory.current));
+  } on ReleaseToolException catch (error) {
+    stderr.writeln('Failed to read version: ${error.message}');
+    exitCode = 1;
+  } on FileSystemException catch (error) {
+    stderr.writeln('Failed to read version: ${error.message}');
+    exitCode = 1;
+  }
+}

--- a/tool/src/release_project.dart
+++ b/tool/src/release_project.dart
@@ -35,6 +35,9 @@ final class ReleaseToolException implements Exception {
   String toString() => message;
 }
 
+/// Returns the package version declared in `pubspec.yaml` under [root].
+String readPubspecVersion(Directory root) => _readProject(root).version;
+
 /// Updates every release version reference under [root].
 ///
 /// All inputs are validated before any file is written. The returned paths are


### PR DESCRIPTION
## 概要

Issue #57で定義したリリースフローの自動化を実装します。

## 変更内容

- Prepare Releaseワークフローによるバージョン更新、releaseブランチ作成、PR作成
- mainマージ後のリリースタグ自動作成
- 公開タグがmain上にあることの検証
- 公開完了後のmainからdevelopへの自動マージバック
- pubspecバージョン取得CLIと単体テストの追加
- GitHub AppのClient IDと秘密鍵による認証

## 検証

- dart format --output=none --set-exit-if-changed .
- dart analyze --fatal-infos
- dart test --exclude-tags e2e（571件成功）
- dart pub publish --dry-run（警告0件）
- GitHub Actions YAML構文確認

## 残作業

- 初回のmainからdevelopへの履歴統合
- プレリリース版での一連の動作確認

Refs #57