### PR TITLE
fix: updateMetaの設定送信を安全にする

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `AdminApi.updateMeta(extra:)` for passing newer upstream or fork-specific instance settings that do not yet have typed parameters (issue #23)
+
+### Removed
+
+- **Breaking:** Removed the ineffective typed `proxyAccountId` parameter from `AdminApi.updateMeta()`. Current upstream Misskey does not accept that setting on `/admin/update-meta`; callers targeting an older version or compatible fork may send it through `extra` only after confirming server support (issue #9)
+
+### Fixed
+
+- `AdminApi.updateMeta()` now treats an invocation without settings as a no-op instead of sending an empty update that current upstream Misskey rejects with a 500 response
+
 ## [1.0.0-beta.8] - 2026-08-25
 
 ### Changed

--- a/lib/src/api/admin/admin_api.dart
+++ b/lib/src/api/admin/admin_api.dart
@@ -40,9 +40,26 @@ class AdminApi {
   /// Nullable settings use the [Optional] type: pass `Optional('value')`
   /// to set and `Optional.null_()` to clear.
   ///
+  /// Only a commonly used subset of the upstream settings is exposed as typed
+  /// parameters. Pass settings that are not typed yet, including settings
+  /// added by newer Misskey versions or compatible forks, through [extra].
+  /// When [extra] and a typed parameter contain the same key, the typed
+  /// parameter takes precedence. The contents of [extra] are otherwise sent
+  /// without schema or JSON-value validation; callers are responsible for
+  /// ensuring that every key and value is accepted by the target server.
+  ///
+  /// The authentication key `i` is reserved for the client and must not be
+  /// included in [extra]. Current upstream Misskey does not accept
+  /// `proxyAccountId` on this endpoint: sending it alone can fail with a 500
+  /// response, while sending it with other settings can silently ignore it.
+  /// Include that key in [extra] only after confirming that the target server
+  /// version or fork accepts it. An invocation with no typed parameters and a
+  /// null or empty [extra] is a no-op and does not send an empty update.
+  ///
   /// [federation] accepts `all`, `specified`, or `none`. When it is
   /// `specified`, [federationHosts] lists the hosts allowed to federate.
   Future<void> updateMeta({
+    Map<String, dynamic>? extra,
     Optional<String>? name,
     Optional<String>? description,
     Optional<String>? maintainerName,
@@ -51,7 +68,6 @@ class AdminApi {
     Optional<String>? privacyPolicyUrl,
     Optional<String>? impressumUrl,
     Optional<String>? inquiryUrl,
-    Optional<String>? proxyAccountId,
     bool? disableRegistration,
     bool? emailRequiredForSignup,
     bool? enableEmail,
@@ -70,7 +86,15 @@ class AdminApi {
     List<String>? hiddenTags,
     List<String>? preservedUsernames,
   }) async {
+    if (extra?.containsKey('i') ?? false) {
+      throw ArgumentError.value(
+        extra,
+        'extra',
+        'must not contain the reserved authentication key "i"',
+      );
+    }
     final body = <String, dynamic>{
+      ...?extra,
       'disableRegistration': ?disableRegistration,
       'emailRequiredForSignup': ?emailRequiredForSignup,
       'enableEmail': ?enableEmail,
@@ -97,7 +121,9 @@ class AdminApi {
     putOptional(body, 'privacyPolicyUrl', privacyPolicyUrl);
     putOptional(body, 'impressumUrl', impressumUrl);
     putOptional(body, 'inquiryUrl', inquiryUrl);
-    putOptional(body, 'proxyAccountId', proxyAccountId);
+    if (body.isEmpty) {
+      return;
+    }
     await http.send<Object?>('/admin/update-meta', body: body);
   }
 

--- a/test/api/admin_api_test.dart
+++ b/test/api/admin_api_test.dart
@@ -1,0 +1,143 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:misskey_client/misskey_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('AdminApi.updateMeta', () {
+    test('sends typed and untyped instance settings', () async {
+      final adapter = _RecordingHttpClientAdapter();
+      final client = _createClient(adapter);
+      addTearDown(client.dispose);
+
+      await client.admin.updateMeta(
+        extra: const {
+          'objectStorageBaseUrl': 'https://storage.example.com',
+          'enableFanoutTimeline': true,
+        },
+        disableRegistration: false,
+        blockedHosts: const [],
+      );
+
+      expect(adapter.path, '/api/admin/update-meta');
+      expect(adapter.body, {
+        'objectStorageBaseUrl': 'https://storage.example.com',
+        'enableFanoutTimeline': true,
+        'disableRegistration': false,
+        'blockedHosts': <String>[],
+      });
+    });
+
+    test('typed parameters take precedence over extra settings', () async {
+      final adapter = _RecordingHttpClientAdapter();
+      final client = _createClient(adapter);
+      addTearDown(client.dispose);
+
+      await client.admin.updateMeta(
+        extra: const {
+          'description': 'from extra',
+          'enableEmail': false,
+          'maintainerEmail': 'extra@example.com',
+        },
+        description: const Optional('typed description'),
+        enableEmail: true,
+      );
+
+      expect(adapter.body, {
+        'description': 'typed description',
+        'enableEmail': true,
+        'maintainerEmail': 'extra@example.com',
+      });
+    });
+
+    test('Optional.null_ sends an explicit null over extra', () async {
+      final adapter = _RecordingHttpClientAdapter();
+      final client = _createClient(adapter);
+      addTearDown(client.dispose);
+
+      await client.admin.updateMeta(
+        extra: const {'description': 'from extra'},
+        description: const Optional.null_(),
+      );
+
+      expect(adapter.body, {'description': null});
+    });
+
+    test('does not send an empty update', () async {
+      final adapter = _RecordingHttpClientAdapter();
+      final client = _createClient(adapter);
+      addTearDown(client.dispose);
+
+      await client.admin.updateMeta();
+      await client.admin.updateMeta(extra: const {});
+
+      expect(adapter.requestCount, 0);
+    });
+
+    test(
+      'passes proxyAccountId only when explicitly supplied through extra',
+      () async {
+        final adapter = _RecordingHttpClientAdapter();
+        final client = _createClient(adapter);
+        addTearDown(client.dispose);
+
+        await client.admin.updateMeta(
+          extra: const {'proxyAccountId': 'compatible-proxy-account'},
+        );
+
+        expect(adapter.requestCount, 1);
+        expect(adapter.body, {'proxyAccountId': 'compatible-proxy-account'});
+      },
+    );
+
+    test('rejects the reserved authentication key in extra', () async {
+      final adapter = _RecordingHttpClientAdapter();
+      final client = _createClient(adapter);
+      addTearDown(client.dispose);
+
+      await expectLater(
+        client.admin.updateMeta(extra: const {'i': 'other-token'}),
+        throwsArgumentError,
+      );
+
+      expect(adapter.requestCount, 0);
+    });
+  });
+}
+
+MisskeyClient _createClient(_RecordingHttpClientAdapter adapter) =>
+    MisskeyClient(
+      config: MisskeyClientConfig(
+        baseUrl: Uri.parse('https://misskey.example.com'),
+      ),
+      httpClientAdapter: adapter,
+    );
+
+final class _RecordingHttpClientAdapter implements HttpClientAdapter {
+  String? path;
+  Map<String, dynamic>? body;
+  int requestCount = 0;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requestCount++;
+    path = options.uri.path;
+    body = options.data as Map<String, dynamic>;
+    return ResponseBody.fromString(
+      jsonEncode(null),
+      200,
+      headers: {
+        Headers.contentTypeHeader: ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}

--- a/test/e2e/misskey_admin_e2e_test.dart
+++ b/test/e2e/misskey_admin_e2e_test.dart
@@ -43,6 +43,24 @@ void main() {
       expect(restored.description, isNull);
     });
 
+    test('updateMeta extra updates and restores an untyped setting', () async {
+      final before = await admin.admin.meta();
+      final original = before.raw['enableFanoutTimeline'] as bool;
+      final changed = !original;
+
+      try {
+        await admin.admin.updateMeta(extra: {'enableFanoutTimeline': changed});
+        final updated = await admin.admin.meta();
+        expect(updated.raw['enableFanoutTimeline'], changed);
+      } finally {
+        // インスタンス全体の設定なので、検証失敗時も必ず元の値に戻す。
+        await admin.admin.updateMeta(extra: {'enableFanoutTimeline': original});
+      }
+
+      final restored = await admin.admin.meta();
+      expect(restored.raw['enableFanoutTimeline'], original);
+    });
+
     test('serverInfo returns software versions', () async {
       final info = await admin.admin.serverInfo();
       expect(info.node, startsWith('v'));


### PR DESCRIPTION
## 概要

- 現行Misskeyで受理されない `AdminApi.updateMeta(proxyAccountId:)` を削除
- 未型付けの管理設定を送れる `extra` を追加し、型付き引数を優先
- 認証予約キー `i` を拒否し、空更新はHTTP送信しない
- 現行上流での `proxyAccountId` の500・黙殺リスクをdartdocへ明記
- 未型付け設定の更新・読戻し・復元を行うAdmin E2Eを追加

## レビュー

別担当の独立レビューで、`proxyAccountId` を `extra` でも全面拒否すると旧版・対応フォーク向けパススルー契約と矛盾する指摘を受けました。型付き引数の削除は維持し、対象サーバーで対応確認済みの場合のみ `extra` から明示送信できる設計へ修正し、再レビュー承認済みです。

## 検証

- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm dart analyze --fatal-infos`
- `fvm dart run build_runner build` + 生成差分なし
- `fvm dart test --exclude-tags e2e`: 577件成功
- `fvm dart pub publish --dry-run`: warning 0
- マージ判断の再現可能な根拠: 上記のCI・単体/adapterテスト。ローカルE2E結果は、外部レビュアーが再現できないmaintainer-onlyの補助検証として別コメントに記録

Closes #9
Closes #23