### PR TITLE
feat: 通知と下書きの欠落ペイロードを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added the typed `exportedEntity`, `fileId`, `invitation`, and `noteDraft` payloads to `MisskeyNotification`, including a forward-compatible fallback for unknown export entity types (issue #19)
+- Added the embedded `user`, `files`, `channel`, `renote`, and `reply` relationships to `MisskeyNoteDraft`; draft channels use a dedicated partial model matching the server response (issue #20)
+
 ## [1.0.0-beta.8] - 2026-08-25
 
 ### Changed

--- a/lib/misskey_client.dart
+++ b/lib/misskey_client.dart
@@ -114,6 +114,7 @@ export 'src/models/misskey_invite_code.dart';
 export 'src/models/misskey_muting.dart';
 export 'src/models/misskey_note.dart';
 export 'src/models/misskey_note_draft.dart';
+export 'src/models/misskey_note_draft_channel.dart';
 export 'src/models/misskey_note_draft_poll.dart';
 export 'src/models/misskey_note_favorite.dart';
 export 'src/models/misskey_note_partial.dart';

--- a/lib/src/models/misskey_note_draft.dart
+++ b/lib/src/models/misskey_note_draft.dart
@@ -1,7 +1,11 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 import 'json_converters.dart';
+import 'misskey_drive_file.dart';
+import 'misskey_note.dart';
+import 'misskey_note_draft_channel.dart';
 import 'misskey_note_draft_poll.dart';
+import 'misskey_user.dart';
 
 part 'misskey_note_draft.freezed.dart';
 part 'misskey_note_draft.g.dart';
@@ -15,6 +19,7 @@ class MisskeyNoteDraft with _$MisskeyNoteDraft {
     required this.createdAt,
     required this.updatedAt,
     required this.userId,
+    this.user,
     this.visibility,
     this.visibleUserIds,
     this.cw,
@@ -26,6 +31,10 @@ class MisskeyNoteDraft with _$MisskeyNoteDraft {
     this.channelId,
     this.text,
     this.fileIds,
+    this.files,
+    this.channel,
+    this.renote,
+    this.reply,
     this.poll,
     this.scheduledAt,
     this.isActuallyScheduled,
@@ -52,6 +61,10 @@ class MisskeyNoteDraft with _$MisskeyNoteDraft {
   /// The ID of the user who owns this draft.
   @override
   final String userId;
+
+  /// The user who owns this draft.
+  @override
+  final MisskeyUser? user;
 
   /// The visibility scope (`public` / `home` / `followers` / `specified`).
   @override
@@ -99,6 +112,22 @@ class MisskeyNoteDraft with _$MisskeyNoteDraft {
   @JsonKey(defaultValue: <String>[])
   @override
   final List<String>? fileIds;
+
+  /// The files attached to this draft.
+  @override
+  final List<MisskeyDriveFile>? files;
+
+  /// The partial channel information embedded in this draft.
+  @override
+  final MisskeyNoteDraftChannel? channel;
+
+  /// The note renoted by this draft.
+  @override
+  final MisskeyNote? renote;
+
+  /// The note replied to by this draft.
+  @override
+  final MisskeyNote? reply;
 
   /// The poll attached to this draft.
   ///

--- a/lib/src/models/misskey_note_draft.freezed.dart
+++ b/lib/src/models/misskey_note_draft.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$MisskeyNoteDraft {
 
- String get id; DateTime get createdAt; DateTime? get updatedAt; String get userId; String? get visibility; List<String>? get visibleUserIds; String? get cw; String? get hashtag; bool? get localOnly; String? get reactionAcceptance; String? get replyId; String? get renoteId; String? get channelId; String? get text; List<String>? get fileIds; MisskeyNoteDraftPoll? get poll; int? get scheduledAt; bool? get isActuallyScheduled;
+ String get id; DateTime get createdAt; DateTime? get updatedAt; String get userId; MisskeyUser? get user; String? get visibility; List<String>? get visibleUserIds; String? get cw; String? get hashtag; bool? get localOnly; String? get reactionAcceptance; String? get replyId; String? get renoteId; String? get channelId; String? get text; List<String>? get fileIds; List<MisskeyDriveFile>? get files; MisskeyNoteDraftChannel? get channel; MisskeyNote? get renote; MisskeyNote? get reply; MisskeyNoteDraftPoll? get poll; int? get scheduledAt; bool? get isActuallyScheduled;
 /// Create a copy of MisskeyNoteDraft
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -26,16 +26,16 @@ $MisskeyNoteDraftCopyWith<MisskeyNoteDraft> get copyWith => _$MisskeyNoteDraftCo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is MisskeyNoteDraft&&(identical(other.id, id) || other.id == id)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.visibility, visibility) || other.visibility == visibility)&&const DeepCollectionEquality().equals(other.visibleUserIds, visibleUserIds)&&(identical(other.cw, cw) || other.cw == cw)&&(identical(other.hashtag, hashtag) || other.hashtag == hashtag)&&(identical(other.localOnly, localOnly) || other.localOnly == localOnly)&&(identical(other.reactionAcceptance, reactionAcceptance) || other.reactionAcceptance == reactionAcceptance)&&(identical(other.replyId, replyId) || other.replyId == replyId)&&(identical(other.renoteId, renoteId) || other.renoteId == renoteId)&&(identical(other.channelId, channelId) || other.channelId == channelId)&&(identical(other.text, text) || other.text == text)&&const DeepCollectionEquality().equals(other.fileIds, fileIds)&&(identical(other.poll, poll) || other.poll == poll)&&(identical(other.scheduledAt, scheduledAt) || other.scheduledAt == scheduledAt)&&(identical(other.isActuallyScheduled, isActuallyScheduled) || other.isActuallyScheduled == isActuallyScheduled));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MisskeyNoteDraft&&(identical(other.id, id) || other.id == id)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.user, user) || other.user == user)&&(identical(other.visibility, visibility) || other.visibility == visibility)&&const DeepCollectionEquality().equals(other.visibleUserIds, visibleUserIds)&&(identical(other.cw, cw) || other.cw == cw)&&(identical(other.hashtag, hashtag) || other.hashtag == hashtag)&&(identical(other.localOnly, localOnly) || other.localOnly == localOnly)&&(identical(other.reactionAcceptance, reactionAcceptance) || other.reactionAcceptance == reactionAcceptance)&&(identical(other.replyId, replyId) || other.replyId == replyId)&&(identical(other.renoteId, renoteId) || other.renoteId == renoteId)&&(identical(other.channelId, channelId) || other.channelId == channelId)&&(identical(other.text, text) || other.text == text)&&const DeepCollectionEquality().equals(other.fileIds, fileIds)&&const DeepCollectionEquality().equals(other.files, files)&&(identical(other.channel, channel) || other.channel == channel)&&(identical(other.renote, renote) || other.renote == renote)&&(identical(other.reply, reply) || other.reply == reply)&&(identical(other.poll, poll) || other.poll == poll)&&(identical(other.scheduledAt, scheduledAt) || other.scheduledAt == scheduledAt)&&(identical(other.isActuallyScheduled, isActuallyScheduled) || other.isActuallyScheduled == isActuallyScheduled));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,createdAt,updatedAt,userId,visibility,const DeepCollectionEquality().hash(visibleUserIds),cw,hashtag,localOnly,reactionAcceptance,replyId,renoteId,channelId,text,const DeepCollectionEquality().hash(fileIds),poll,scheduledAt,isActuallyScheduled);
+int get hashCode => Object.hashAll([runtimeType,id,createdAt,updatedAt,userId,user,visibility,const DeepCollectionEquality().hash(visibleUserIds),cw,hashtag,localOnly,reactionAcceptance,replyId,renoteId,channelId,text,const DeepCollectionEquality().hash(fileIds),const DeepCollectionEquality().hash(files),channel,renote,reply,poll,scheduledAt,isActuallyScheduled]);
 
 @override
 String toString() {
-  return 'MisskeyNoteDraft(id: $id, createdAt: $createdAt, updatedAt: $updatedAt, userId: $userId, visibility: $visibility, visibleUserIds: $visibleUserIds, cw: $cw, hashtag: $hashtag, localOnly: $localOnly, reactionAcceptance: $reactionAcceptance, replyId: $replyId, renoteId: $renoteId, channelId: $channelId, text: $text, fileIds: $fileIds, poll: $poll, scheduledAt: $scheduledAt, isActuallyScheduled: $isActuallyScheduled)';
+  return 'MisskeyNoteDraft(id: $id, createdAt: $createdAt, updatedAt: $updatedAt, userId: $userId, user: $user, visibility: $visibility, visibleUserIds: $visibleUserIds, cw: $cw, hashtag: $hashtag, localOnly: $localOnly, reactionAcceptance: $reactionAcceptance, replyId: $replyId, renoteId: $renoteId, channelId: $channelId, text: $text, fileIds: $fileIds, files: $files, channel: $channel, renote: $renote, reply: $reply, poll: $poll, scheduledAt: $scheduledAt, isActuallyScheduled: $isActuallyScheduled)';
 }
 
 
@@ -46,7 +46,7 @@ abstract mixin class $MisskeyNoteDraftCopyWith<$Res>  {
   factory $MisskeyNoteDraftCopyWith(MisskeyNoteDraft value, $Res Function(MisskeyNoteDraft) _then) = _$MisskeyNoteDraftCopyWithImpl;
 @useResult
 $Res call({
- String id, DateTime createdAt, DateTime? updatedAt, String userId, String? visibility, List<String>? visibleUserIds, String? cw, String? hashtag, bool? localOnly, String? reactionAcceptance, String? replyId, String? renoteId, String? channelId, String? text, List<String>? fileIds, MisskeyNoteDraftPoll? poll, int? scheduledAt, bool? isActuallyScheduled
+ String id, DateTime createdAt, DateTime? updatedAt, String userId, MisskeyUser? user, String? visibility, List<String>? visibleUserIds, String? cw, String? hashtag, bool? localOnly, String? reactionAcceptance, String? replyId, String? renoteId, String? channelId, String? text, List<String>? fileIds, List<MisskeyDriveFile>? files, MisskeyNoteDraftChannel? channel, MisskeyNote? renote, MisskeyNote? reply, MisskeyNoteDraftPoll? poll, int? scheduledAt, bool? isActuallyScheduled
 });
 
 
@@ -63,13 +63,14 @@ class _$MisskeyNoteDraftCopyWithImpl<$Res>
 
 /// Create a copy of MisskeyNoteDraft
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? createdAt = null,Object? updatedAt = freezed,Object? userId = null,Object? visibility = freezed,Object? visibleUserIds = freezed,Object? cw = freezed,Object? hashtag = freezed,Object? localOnly = freezed,Object? reactionAcceptance = freezed,Object? replyId = freezed,Object? renoteId = freezed,Object? channelId = freezed,Object? text = freezed,Object? fileIds = freezed,Object? poll = freezed,Object? scheduledAt = freezed,Object? isActuallyScheduled = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? createdAt = null,Object? updatedAt = freezed,Object? userId = null,Object? user = freezed,Object? visibility = freezed,Object? visibleUserIds = freezed,Object? cw = freezed,Object? hashtag = freezed,Object? localOnly = freezed,Object? reactionAcceptance = freezed,Object? replyId = freezed,Object? renoteId = freezed,Object? channelId = freezed,Object? text = freezed,Object? fileIds = freezed,Object? files = freezed,Object? channel = freezed,Object? renote = freezed,Object? reply = freezed,Object? poll = freezed,Object? scheduledAt = freezed,Object? isActuallyScheduled = freezed,}) {
   return _then(MisskeyNoteDraft(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
 as DateTime,updatedAt: freezed == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
-as String,visibility: freezed == visibility ? _self.visibility : visibility // ignore: cast_nullable_to_non_nullable
+as String,user: freezed == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as MisskeyUser?,visibility: freezed == visibility ? _self.visibility : visibility // ignore: cast_nullable_to_non_nullable
 as String?,visibleUserIds: freezed == visibleUserIds ? _self.visibleUserIds : visibleUserIds // ignore: cast_nullable_to_non_nullable
 as List<String>?,cw: freezed == cw ? _self.cw : cw // ignore: cast_nullable_to_non_nullable
 as String?,hashtag: freezed == hashtag ? _self.hashtag : hashtag // ignore: cast_nullable_to_non_nullable
@@ -80,7 +81,11 @@ as String?,renoteId: freezed == renoteId ? _self.renoteId : renoteId // ignore: 
 as String?,channelId: freezed == channelId ? _self.channelId : channelId // ignore: cast_nullable_to_non_nullable
 as String?,text: freezed == text ? _self.text : text // ignore: cast_nullable_to_non_nullable
 as String?,fileIds: freezed == fileIds ? _self.fileIds : fileIds // ignore: cast_nullable_to_non_nullable
-as List<String>?,poll: freezed == poll ? _self.poll : poll // ignore: cast_nullable_to_non_nullable
+as List<String>?,files: freezed == files ? _self.files : files // ignore: cast_nullable_to_non_nullable
+as List<MisskeyDriveFile>?,channel: freezed == channel ? _self.channel : channel // ignore: cast_nullable_to_non_nullable
+as MisskeyNoteDraftChannel?,renote: freezed == renote ? _self.renote : renote // ignore: cast_nullable_to_non_nullable
+as MisskeyNote?,reply: freezed == reply ? _self.reply : reply // ignore: cast_nullable_to_non_nullable
+as MisskeyNote?,poll: freezed == poll ? _self.poll : poll // ignore: cast_nullable_to_non_nullable
 as MisskeyNoteDraftPoll?,scheduledAt: freezed == scheduledAt ? _self.scheduledAt : scheduledAt // ignore: cast_nullable_to_non_nullable
 as int?,isActuallyScheduled: freezed == isActuallyScheduled ? _self.isActuallyScheduled : isActuallyScheduled // ignore: cast_nullable_to_non_nullable
 as bool?,

--- a/lib/src/models/misskey_note_draft.g.dart
+++ b/lib/src/models/misskey_note_draft.g.dart
@@ -14,6 +14,9 @@ MisskeyNoteDraft _$MisskeyNoteDraftFromJson(Map<String, dynamic> json) =>
         json['updatedAt'] as String?,
       ),
       userId: json['userId'] as String,
+      user: json['user'] == null
+          ? null
+          : MisskeyUser.fromJson(json['user'] as Map<String, dynamic>),
       visibility: json['visibility'] as String?,
       visibleUserIds:
           (json['visibleUserIds'] as List<dynamic>?)
@@ -33,6 +36,20 @@ MisskeyNoteDraft _$MisskeyNoteDraftFromJson(Map<String, dynamic> json) =>
               ?.map((e) => e as String)
               .toList() ??
           [],
+      files: (json['files'] as List<dynamic>?)
+          ?.map((e) => MisskeyDriveFile.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      channel: json['channel'] == null
+          ? null
+          : MisskeyNoteDraftChannel.fromJson(
+              json['channel'] as Map<String, dynamic>,
+            ),
+      renote: json['renote'] == null
+          ? null
+          : MisskeyNote.fromJson(json['renote'] as Map<String, dynamic>),
+      reply: json['reply'] == null
+          ? null
+          : MisskeyNote.fromJson(json['reply'] as Map<String, dynamic>),
       poll: json['poll'] == null
           ? null
           : MisskeyNoteDraftPoll.fromJson(json['poll'] as Map<String, dynamic>),
@@ -46,6 +63,7 @@ Map<String, dynamic> _$MisskeyNoteDraftToJson(MisskeyNoteDraft instance) =>
       'createdAt': instance.createdAt.toIso8601String(),
       'updatedAt': const SafeDateTimeConverter().toJson(instance.updatedAt),
       'userId': instance.userId,
+      'user': instance.user?.toJson(),
       'visibility': instance.visibility,
       'visibleUserIds': instance.visibleUserIds,
       'cw': instance.cw,
@@ -57,6 +75,10 @@ Map<String, dynamic> _$MisskeyNoteDraftToJson(MisskeyNoteDraft instance) =>
       'channelId': instance.channelId,
       'text': instance.text,
       'fileIds': instance.fileIds,
+      'files': instance.files?.map((e) => e.toJson()).toList(),
+      'channel': instance.channel?.toJson(),
+      'renote': instance.renote?.toJson(),
+      'reply': instance.reply?.toJson(),
       'poll': instance.poll?.toJson(),
       'scheduledAt': instance.scheduledAt,
       'isActuallyScheduled': instance.isActuallyScheduled,

--- a/lib/src/models/misskey_note_draft_channel.dart
+++ b/lib/src/models/misskey_note_draft_channel.dart
@@ -1,0 +1,50 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'misskey_note_draft_channel.freezed.dart';
+part 'misskey_note_draft_channel.g.dart';
+
+/// The partial channel information embedded in a note draft.
+///
+/// Unlike a full channel response, a draft does not include fields such as
+/// the channel creation timestamp.
+@freezed
+@JsonSerializable()
+class MisskeyNoteDraftChannel with _$MisskeyNoteDraftChannel {
+  const MisskeyNoteDraftChannel({
+    required this.id,
+    required this.name,
+    required this.color,
+    required this.isSensitive,
+    required this.allowRenoteToExternal,
+    this.userId,
+  });
+
+  factory MisskeyNoteDraftChannel.fromJson(Map<String, dynamic> json) =>
+      _$MisskeyNoteDraftChannelFromJson(json);
+
+  Map<String, dynamic> toJson() => _$MisskeyNoteDraftChannelToJson(this);
+
+  /// The channel ID.
+  @override
+  final String id;
+
+  /// The channel name.
+  @override
+  final String name;
+
+  /// The channel theme color.
+  @override
+  final String color;
+
+  /// Whether the channel is marked as sensitive.
+  @override
+  final bool isSensitive;
+
+  /// Whether renotes to external channels are allowed.
+  @override
+  final bool allowRenoteToExternal;
+
+  /// The owner user's ID.
+  @override
+  final String? userId;
+}

--- a/lib/src/models/misskey_note_draft_channel.freezed.dart
+++ b/lib/src/models/misskey_note_draft_channel.freezed.dart
@@ -1,0 +1,205 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'misskey_note_draft_channel.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$MisskeyNoteDraftChannel {
+
+ String get id; String get name; String get color; bool get isSensitive; bool get allowRenoteToExternal; String? get userId;
+/// Create a copy of MisskeyNoteDraftChannel
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$MisskeyNoteDraftChannelCopyWith<MisskeyNoteDraftChannel> get copyWith => _$MisskeyNoteDraftChannelCopyWithImpl<MisskeyNoteDraftChannel>(this as MisskeyNoteDraftChannel, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MisskeyNoteDraftChannel&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.color, color) || other.color == color)&&(identical(other.isSensitive, isSensitive) || other.isSensitive == isSensitive)&&(identical(other.allowRenoteToExternal, allowRenoteToExternal) || other.allowRenoteToExternal == allowRenoteToExternal)&&(identical(other.userId, userId) || other.userId == userId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,name,color,isSensitive,allowRenoteToExternal,userId);
+
+@override
+String toString() {
+  return 'MisskeyNoteDraftChannel(id: $id, name: $name, color: $color, isSensitive: $isSensitive, allowRenoteToExternal: $allowRenoteToExternal, userId: $userId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $MisskeyNoteDraftChannelCopyWith<$Res>  {
+  factory $MisskeyNoteDraftChannelCopyWith(MisskeyNoteDraftChannel value, $Res Function(MisskeyNoteDraftChannel) _then) = _$MisskeyNoteDraftChannelCopyWithImpl;
+@useResult
+$Res call({
+ String id, String name, String color, bool isSensitive, bool allowRenoteToExternal, String? userId
+});
+
+
+
+
+}
+/// @nodoc
+class _$MisskeyNoteDraftChannelCopyWithImpl<$Res>
+    implements $MisskeyNoteDraftChannelCopyWith<$Res> {
+  _$MisskeyNoteDraftChannelCopyWithImpl(this._self, this._then);
+
+  final MisskeyNoteDraftChannel _self;
+  final $Res Function(MisskeyNoteDraftChannel) _then;
+
+/// Create a copy of MisskeyNoteDraftChannel
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? color = null,Object? isSensitive = null,Object? allowRenoteToExternal = null,Object? userId = freezed,}) {
+  return _then(MisskeyNoteDraftChannel(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,color: null == color ? _self.color : color // ignore: cast_nullable_to_non_nullable
+as String,isSensitive: null == isSensitive ? _self.isSensitive : isSensitive // ignore: cast_nullable_to_non_nullable
+as bool,allowRenoteToExternal: null == allowRenoteToExternal ? _self.allowRenoteToExternal : allowRenoteToExternal // ignore: cast_nullable_to_non_nullable
+as bool,userId: freezed == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [MisskeyNoteDraftChannel].
+extension MisskeyNoteDraftChannelPatterns on MisskeyNoteDraftChannel {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+
+}
+
+// dart format on

--- a/lib/src/models/misskey_note_draft_channel.g.dart
+++ b/lib/src/models/misskey_note_draft_channel.g.dart
@@ -1,0 +1,29 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'misskey_note_draft_channel.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+MisskeyNoteDraftChannel _$MisskeyNoteDraftChannelFromJson(
+  Map<String, dynamic> json,
+) => MisskeyNoteDraftChannel(
+  id: json['id'] as String,
+  name: json['name'] as String,
+  color: json['color'] as String,
+  isSensitive: json['isSensitive'] as bool,
+  allowRenoteToExternal: json['allowRenoteToExternal'] as bool,
+  userId: json['userId'] as String?,
+);
+
+Map<String, dynamic> _$MisskeyNoteDraftChannelToJson(
+  MisskeyNoteDraftChannel instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'name': instance.name,
+  'color': instance.color,
+  'isSensitive': instance.isSensitive,
+  'allowRenoteToExternal': instance.allowRenoteToExternal,
+  'userId': instance.userId,
+};

--- a/lib/src/models/misskey_notification.dart
+++ b/lib/src/models/misskey_notification.dart
@@ -1,6 +1,8 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import 'chat/misskey_chat_room_invitation.dart';
 import 'misskey_note.dart';
+import 'misskey_note_draft.dart';
 import 'misskey_user.dart';
 
 part 'misskey_notification.freezed.dart';
@@ -40,6 +42,23 @@ enum MisskeyNotificationType {
   unknown,
 }
 
+/// An entity that a Misskey user can export.
+@JsonEnum()
+enum MisskeyUserExportableEntity {
+  antenna,
+  blocking,
+  clip,
+  customEmoji,
+  favorite,
+  following,
+  muting,
+  note,
+  userList,
+
+  /// An exportable entity not yet known to this client.
+  unknown,
+}
+
 /// A Misskey notification.
 @freezed
 @JsonSerializable()
@@ -60,6 +79,10 @@ class MisskeyNotification with _$MisskeyNotification {
     this.message,
     this.reactions,
     this.users,
+    this.exportedEntity,
+    this.fileId,
+    this.invitation,
+    this.noteDraft,
   });
 
   factory MisskeyNotification.fromJson(Map<String, dynamic> json) =>
@@ -127,4 +150,21 @@ class MisskeyNotification with _$MisskeyNotification {
   /// The list of users for grouped renote notifications.
   @override
   final List<MisskeyUser>? users;
+
+  /// The kind of data produced by an export-completed notification.
+  @JsonKey(unknownEnumValue: MisskeyUserExportableEntity.unknown)
+  @override
+  final MisskeyUserExportableEntity? exportedEntity;
+
+  /// The ID of the exported file produced by an export-completed notification.
+  @override
+  final String? fileId;
+
+  /// The invitation carried by a chat-room-invitation notification.
+  @override
+  final MisskeyChatRoomInvitation? invitation;
+
+  /// The failed draft carried by a scheduled-note-post-failed notification.
+  @override
+  final MisskeyNoteDraft? noteDraft;
 }

--- a/lib/src/models/misskey_notification.freezed.dart
+++ b/lib/src/models/misskey_notification.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$MisskeyNotification {
 
- String get id; DateTime get createdAt; MisskeyNotificationType get type; String? get userId; MisskeyUser? get user; MisskeyNote? get note; String? get reaction; String? get achievement; String? get body; String? get header; String? get icon; dynamic get role; String? get message; List<dynamic>? get reactions; List<MisskeyUser>? get users;
+ String get id; DateTime get createdAt; MisskeyNotificationType get type; String? get userId; MisskeyUser? get user; MisskeyNote? get note; String? get reaction; String? get achievement; String? get body; String? get header; String? get icon; dynamic get role; String? get message; List<dynamic>? get reactions; List<MisskeyUser>? get users; MisskeyUserExportableEntity? get exportedEntity; String? get fileId; MisskeyChatRoomInvitation? get invitation; MisskeyNoteDraft? get noteDraft;
 /// Create a copy of MisskeyNotification
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -26,16 +26,16 @@ $MisskeyNotificationCopyWith<MisskeyNotification> get copyWith => _$MisskeyNotif
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is MisskeyNotification&&(identical(other.id, id) || other.id == id)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.type, type) || other.type == type)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.user, user) || other.user == user)&&(identical(other.note, note) || other.note == note)&&(identical(other.reaction, reaction) || other.reaction == reaction)&&(identical(other.achievement, achievement) || other.achievement == achievement)&&(identical(other.body, body) || other.body == body)&&(identical(other.header, header) || other.header == header)&&(identical(other.icon, icon) || other.icon == icon)&&const DeepCollectionEquality().equals(other.role, role)&&(identical(other.message, message) || other.message == message)&&const DeepCollectionEquality().equals(other.reactions, reactions)&&const DeepCollectionEquality().equals(other.users, users));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MisskeyNotification&&(identical(other.id, id) || other.id == id)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.type, type) || other.type == type)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.user, user) || other.user == user)&&(identical(other.note, note) || other.note == note)&&(identical(other.reaction, reaction) || other.reaction == reaction)&&(identical(other.achievement, achievement) || other.achievement == achievement)&&(identical(other.body, body) || other.body == body)&&(identical(other.header, header) || other.header == header)&&(identical(other.icon, icon) || other.icon == icon)&&const DeepCollectionEquality().equals(other.role, role)&&(identical(other.message, message) || other.message == message)&&const DeepCollectionEquality().equals(other.reactions, reactions)&&const DeepCollectionEquality().equals(other.users, users)&&(identical(other.exportedEntity, exportedEntity) || other.exportedEntity == exportedEntity)&&(identical(other.fileId, fileId) || other.fileId == fileId)&&(identical(other.invitation, invitation) || other.invitation == invitation)&&(identical(other.noteDraft, noteDraft) || other.noteDraft == noteDraft));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,createdAt,type,userId,user,note,reaction,achievement,body,header,icon,const DeepCollectionEquality().hash(role),message,const DeepCollectionEquality().hash(reactions),const DeepCollectionEquality().hash(users));
+int get hashCode => Object.hashAll([runtimeType,id,createdAt,type,userId,user,note,reaction,achievement,body,header,icon,const DeepCollectionEquality().hash(role),message,const DeepCollectionEquality().hash(reactions),const DeepCollectionEquality().hash(users),exportedEntity,fileId,invitation,noteDraft]);
 
 @override
 String toString() {
-  return 'MisskeyNotification(id: $id, createdAt: $createdAt, type: $type, userId: $userId, user: $user, note: $note, reaction: $reaction, achievement: $achievement, body: $body, header: $header, icon: $icon, role: $role, message: $message, reactions: $reactions, users: $users)';
+  return 'MisskeyNotification(id: $id, createdAt: $createdAt, type: $type, userId: $userId, user: $user, note: $note, reaction: $reaction, achievement: $achievement, body: $body, header: $header, icon: $icon, role: $role, message: $message, reactions: $reactions, users: $users, exportedEntity: $exportedEntity, fileId: $fileId, invitation: $invitation, noteDraft: $noteDraft)';
 }
 
 
@@ -46,7 +46,7 @@ abstract mixin class $MisskeyNotificationCopyWith<$Res>  {
   factory $MisskeyNotificationCopyWith(MisskeyNotification value, $Res Function(MisskeyNotification) _then) = _$MisskeyNotificationCopyWithImpl;
 @useResult
 $Res call({
- String id, DateTime createdAt, MisskeyNotificationType type, String? userId, MisskeyUser? user, MisskeyNote? note, String? reaction, String? achievement, String? body, String? header, String? icon, dynamic role, String? message, List<dynamic>? reactions, List<MisskeyUser>? users
+ String id, DateTime createdAt, MisskeyNotificationType type, String? userId, MisskeyUser? user, MisskeyNote? note, String? reaction, String? achievement, String? body, String? header, String? icon, dynamic role, String? message, List<dynamic>? reactions, List<MisskeyUser>? users, MisskeyUserExportableEntity? exportedEntity, String? fileId, MisskeyChatRoomInvitation? invitation, MisskeyNoteDraft? noteDraft
 });
 
 
@@ -63,7 +63,7 @@ class _$MisskeyNotificationCopyWithImpl<$Res>
 
 /// Create a copy of MisskeyNotification
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? createdAt = null,Object? type = null,Object? userId = freezed,Object? user = freezed,Object? note = freezed,Object? reaction = freezed,Object? achievement = freezed,Object? body = freezed,Object? header = freezed,Object? icon = freezed,Object? role = freezed,Object? message = freezed,Object? reactions = freezed,Object? users = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? createdAt = null,Object? type = null,Object? userId = freezed,Object? user = freezed,Object? note = freezed,Object? reaction = freezed,Object? achievement = freezed,Object? body = freezed,Object? header = freezed,Object? icon = freezed,Object? role = freezed,Object? message = freezed,Object? reactions = freezed,Object? users = freezed,Object? exportedEntity = freezed,Object? fileId = freezed,Object? invitation = freezed,Object? noteDraft = freezed,}) {
   return _then(MisskeyNotification(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
@@ -80,7 +80,11 @@ as String?,role: freezed == role ? _self.role : role // ignore: cast_nullable_to
 as dynamic,message: freezed == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
 as String?,reactions: freezed == reactions ? _self.reactions : reactions // ignore: cast_nullable_to_non_nullable
 as List<dynamic>?,users: freezed == users ? _self.users : users // ignore: cast_nullable_to_non_nullable
-as List<MisskeyUser>?,
+as List<MisskeyUser>?,exportedEntity: freezed == exportedEntity ? _self.exportedEntity : exportedEntity // ignore: cast_nullable_to_non_nullable
+as MisskeyUserExportableEntity?,fileId: freezed == fileId ? _self.fileId : fileId // ignore: cast_nullable_to_non_nullable
+as String?,invitation: freezed == invitation ? _self.invitation : invitation // ignore: cast_nullable_to_non_nullable
+as MisskeyChatRoomInvitation?,noteDraft: freezed == noteDraft ? _self.noteDraft : noteDraft // ignore: cast_nullable_to_non_nullable
+as MisskeyNoteDraft?,
   ));
 }
 

--- a/lib/src/models/misskey_notification.g.dart
+++ b/lib/src/models/misskey_notification.g.dart
@@ -33,6 +33,22 @@ MisskeyNotification _$MisskeyNotificationFromJson(Map<String, dynamic> json) =>
       users: (json['users'] as List<dynamic>?)
           ?.map((e) => MisskeyUser.fromJson(e as Map<String, dynamic>))
           .toList(),
+      exportedEntity: $enumDecodeNullable(
+        _$MisskeyUserExportableEntityEnumMap,
+        json['exportedEntity'],
+        unknownValue: MisskeyUserExportableEntity.unknown,
+      ),
+      fileId: json['fileId'] as String?,
+      invitation: json['invitation'] == null
+          ? null
+          : MisskeyChatRoomInvitation.fromJson(
+              json['invitation'] as Map<String, dynamic>,
+            ),
+      noteDraft: json['noteDraft'] == null
+          ? null
+          : MisskeyNoteDraft.fromJson(
+              json['noteDraft'] as Map<String, dynamic>,
+            ),
     );
 
 Map<String, dynamic> _$MisskeyNotificationToJson(
@@ -53,6 +69,11 @@ Map<String, dynamic> _$MisskeyNotificationToJson(
   'message': instance.message,
   'reactions': instance.reactions,
   'users': instance.users?.map((e) => e.toJson()).toList(),
+  'exportedEntity':
+      _$MisskeyUserExportableEntityEnumMap[instance.exportedEntity],
+  'fileId': instance.fileId,
+  'invitation': instance.invitation?.toJson(),
+  'noteDraft': instance.noteDraft?.toJson(),
 };
 
 const _$MisskeyNotificationTypeEnumMap = {
@@ -80,4 +101,17 @@ const _$MisskeyNotificationTypeEnumMap = {
   MisskeyNotificationType.reactionGrouped: 'reaction:grouped',
   MisskeyNotificationType.renoteGrouped: 'renote:grouped',
   MisskeyNotificationType.unknown: 'unknown',
+};
+
+const _$MisskeyUserExportableEntityEnumMap = {
+  MisskeyUserExportableEntity.antenna: 'antenna',
+  MisskeyUserExportableEntity.blocking: 'blocking',
+  MisskeyUserExportableEntity.clip: 'clip',
+  MisskeyUserExportableEntity.customEmoji: 'customEmoji',
+  MisskeyUserExportableEntity.favorite: 'favorite',
+  MisskeyUserExportableEntity.following: 'following',
+  MisskeyUserExportableEntity.muting: 'muting',
+  MisskeyUserExportableEntity.note: 'note',
+  MisskeyUserExportableEntity.userList: 'userList',
+  MisskeyUserExportableEntity.unknown: 'unknown',
 };

--- a/test/fixtures/notifications_schema_examples.json
+++ b/test/fixtures/notifications_schema_examples.json
@@ -1,0 +1,111 @@
+{
+  "provenance": {
+    "kind": "upstream-schema-derived-example",
+    "liveServerCaptured": false,
+    "upstreamRepository": "misskey-dev/misskey",
+    "upstreamCommit": "0b49119a3fb93e7be3a611831d64a1fcbb78e44e",
+    "sources": [
+      "packages/backend/src/models/json-schema/notification.ts",
+      "packages/backend/src/models/json-schema/note-draft.ts",
+      "packages/backend/src/models/json-schema/chat-room-invitation.ts",
+      "packages/backend/src/models/json-schema/chat-room.ts",
+      "packages/backend/src/types.ts"
+    ]
+  },
+  "notifications": [
+    {
+      "id": "notification-export-completed",
+      "createdAt": "2026-08-25T00:00:00.000Z",
+      "type": "exportCompleted",
+      "exportedEntity": "customEmoji",
+      "fileId": "file-export-1"
+    },
+    {
+      "id": "notification-chat-invitation",
+      "createdAt": "2026-08-25T00:01:00.000Z",
+      "type": "chatRoomInvitationReceived",
+      "invitation": {
+        "id": "invitation-1",
+        "createdAt": "2026-08-25T00:00:30.000Z",
+        "userId": "user-inviter",
+        "user": {
+          "id": "user-inviter",
+          "name": "Inviter",
+          "username": "inviter",
+          "host": null,
+          "avatarUrl": "https://example.test/identicon/inviter",
+          "avatarBlurhash": null,
+          "avatarDecorations": [],
+          "isBot": false,
+          "isCat": false,
+          "emojis": {},
+          "onlineStatus": "unknown",
+          "badgeRoles": []
+        },
+        "roomId": "room-1",
+        "room": {
+          "id": "room-1",
+          "createdAt": "2026-08-24T00:00:00.000Z",
+          "ownerId": "user-inviter",
+          "owner": {
+            "id": "user-inviter",
+            "name": "Inviter",
+            "username": "inviter",
+            "host": null,
+            "avatarUrl": "https://example.test/identicon/inviter",
+            "avatarBlurhash": null,
+            "avatarDecorations": [],
+            "isBot": false,
+            "isCat": false,
+            "emojis": {},
+            "onlineStatus": "unknown",
+            "badgeRoles": []
+          },
+          "name": "Schema example room",
+          "description": "A schema-derived chat room example.",
+          "isMuted": false,
+          "invitationExists": true
+        }
+      }
+    },
+    {
+      "id": "notification-scheduled-note-failed",
+      "createdAt": "2026-08-25T00:02:00.000Z",
+      "type": "scheduledNotePostFailed",
+      "noteDraft": {
+        "id": "draft-failed-1",
+        "createdAt": "2026-08-25T00:01:30.000Z",
+        "text": "Failed scheduled draft",
+        "cw": null,
+        "userId": "user-author",
+        "user": {
+          "id": "user-author",
+          "name": "Author",
+          "username": "author",
+          "host": null,
+          "avatarUrl": "https://example.test/identicon/author",
+          "avatarBlurhash": null,
+          "avatarDecorations": [],
+          "isBot": false,
+          "isCat": false,
+          "emojis": {},
+          "onlineStatus": "unknown",
+          "badgeRoles": []
+        },
+        "replyId": null,
+        "renoteId": null,
+        "visibility": "public",
+        "visibleUserIds": [],
+        "fileIds": [],
+        "files": [],
+        "hashtag": null,
+        "poll": null,
+        "channelId": null,
+        "localOnly": false,
+        "reactionAcceptance": null,
+        "scheduledAt": null,
+        "isActuallyScheduled": false
+      }
+    }
+  ]
+}

--- a/test/models/misskey_note_draft_test.dart
+++ b/test/models/misskey_note_draft_test.dart
@@ -31,6 +31,12 @@ void main() {
       expect(draft.userId, 'ak3po4qort4w0001');
     });
 
+    test('includes the owner user returned by the server', () {
+      expect(draft.user, isNotNull);
+      expect(draft.user!.id, draft.userId);
+      expect(draft.user!.username, 'testadmin');
+    });
+
     test('text is correct', () {
       expect(draft.text, 'This is a draft note');
     });
@@ -49,6 +55,10 @@ void main() {
 
     test('fileIds is empty', () {
       expect(draft.fileIds, isEmpty);
+    });
+
+    test('includes the attached files returned by the server', () {
+      expect(draft.files, isEmpty);
     });
 
     test('cw is null', () {
@@ -109,6 +119,86 @@ void main() {
 
     test('expiredAfter is null when no relative deadline was set', () {
       expect(draft.poll!.expiredAfter, isNull);
+    });
+  });
+
+  group('MisskeyNoteDraft.fromJson (with embedded relationships)', () {
+    late MisskeyNoteDraft draft;
+
+    setUp(() {
+      final user = <String, dynamic>{'id': 'user-1', 'username': 'alice'};
+      final note = <String, dynamic>{
+        'id': 'note-1',
+        'createdAt': '2026-08-25T00:00:00.000Z',
+        'userId': 'user-1',
+        'user': user,
+        'text': 'Referenced note',
+      };
+
+      draft = MisskeyNoteDraft.fromJson({
+        'id': 'draft-1',
+        'createdAt': '2026-08-25T01:00:00.000Z',
+        'userId': 'user-1',
+        'user': user,
+        'visibility': 'public',
+        'visibleUserIds': <String>[],
+        'cw': null,
+        'hashtag': null,
+        'localOnly': false,
+        'reactionAcceptance': null,
+        'replyId': 'note-1',
+        'renoteId': 'note-1',
+        'channelId': 'channel-1',
+        'text': 'Draft body',
+        'fileIds': <String>['file-1'],
+        'files': <Map<String, dynamic>>[
+          {
+            'id': 'file-1',
+            'createdAt': '2026-08-25T00:30:00.000Z',
+            'name': 'image.png',
+            'type': 'image/png',
+            'size': 123,
+            'md5': '0123456789abcdef0123456789abcdef',
+            'url': 'https://example.test/files/image.png',
+          },
+        ],
+        'channel': {
+          'id': 'channel-1',
+          'name': 'Draft channel',
+          'color': '#86b300',
+          'isSensitive': false,
+          'allowRenoteToExternal': true,
+          'userId': 'user-1',
+        },
+        'renote': note,
+        'reply': note,
+        'poll': null,
+        'scheduledAt': null,
+        'isActuallyScheduled': false,
+      });
+    });
+
+    test('deserializes a partial channel without full channel fields', () {
+      expect(draft.channel, isNotNull);
+      expect(draft.channel!.id, 'channel-1');
+      expect(draft.channel!.name, 'Draft channel');
+      expect(draft.channel!.color, '#86b300');
+      expect(draft.channel!.isSensitive, isFalse);
+      expect(draft.channel!.allowRenoteToExternal, isTrue);
+      expect(draft.channel!.userId, 'user-1');
+    });
+
+    test('deserializes files, renote, and reply', () {
+      expect(draft.files, hasLength(1));
+      expect(draft.files!.single.id, 'file-1');
+      expect(draft.renote?.id, 'note-1');
+      expect(draft.reply?.id, 'note-1');
+    });
+
+    test('round-trips embedded relationships', () {
+      final roundTripped = MisskeyNoteDraft.fromJson(draft.toJson());
+
+      expect(roundTripped, draft);
     });
   });
 }

--- a/test/models/misskey_notification_test.dart
+++ b/test/models/misskey_notification_test.dart
@@ -118,4 +118,106 @@ void main() {
       expect(notification.type, MisskeyNotificationType.unknown);
     });
   });
+
+  group('MisskeyNotification.fromJson - required type payloads', () {
+    late Map<String, dynamic> fixture;
+    late List<MisskeyNotification> notifications;
+
+    setUpAll(() {
+      fixture =
+          jsonDecode(
+                File(
+                  'test/fixtures/notifications_schema_examples.json',
+                ).readAsStringSync(),
+              )
+              as Map<String, dynamic>;
+      notifications = (fixture['notifications'] as List<dynamic>)
+          .map((e) => MisskeyNotification.fromJson(e as Map<String, dynamic>))
+          .toList();
+    });
+
+    test('fixture records its schema-derived, non-live provenance', () {
+      final provenance = fixture['provenance'] as Map<String, dynamic>;
+
+      expect(provenance['kind'], 'upstream-schema-derived-example');
+      expect(provenance['liveServerCaptured'], isFalse);
+      expect(
+        provenance['upstreamCommit'],
+        '0b49119a3fb93e7be3a611831d64a1fcbb78e44e',
+      );
+    });
+
+    test('deserializes an export-completed payload', () {
+      final notification = notifications.firstWhere(
+        (value) => value.type == MisskeyNotificationType.exportCompleted,
+      );
+
+      expect(notification.type, MisskeyNotificationType.exportCompleted);
+      expect(
+        notification.exportedEntity,
+        MisskeyUserExportableEntity.customEmoji,
+      );
+      expect(notification.fileId, 'file-export-1');
+    });
+
+    test(
+      'falls back for a future export entity without losing the file ID',
+      () {
+        final notification = MisskeyNotification.fromJson({
+          'id': 'notification-future-export',
+          'createdAt': '2026-08-25T00:00:00.000Z',
+          'type': 'exportCompleted',
+          'exportedEntity': 'futureEntity',
+          'fileId': 'file-2',
+        });
+
+        expect(
+          notification.exportedEntity,
+          MisskeyUserExportableEntity.unknown,
+        );
+        expect(notification.fileId, 'file-2');
+      },
+    );
+
+    test('deserializes a chat-room invitation payload', () {
+      final notification = notifications.firstWhere(
+        (value) =>
+            value.type == MisskeyNotificationType.chatRoomInvitationReceived,
+      );
+
+      expect(
+        notification.type,
+        MisskeyNotificationType.chatRoomInvitationReceived,
+      );
+      expect(notification.invitation?.id, 'invitation-1');
+      expect(notification.invitation?.roomId, 'room-1');
+      expect(notification.invitation?.user?.username, 'inviter');
+      expect(notification.invitation?.room?.name, 'Schema example room');
+    });
+
+    test('deserializes a failed scheduled-note draft payload', () {
+      final notification = notifications.firstWhere(
+        (value) =>
+            value.type == MisskeyNotificationType.scheduledNotePostFailed,
+      );
+
+      expect(
+        notification.type,
+        MisskeyNotificationType.scheduledNotePostFailed,
+      );
+      expect(notification.noteDraft?.id, 'draft-failed-1');
+      expect(notification.noteDraft?.user?.username, 'author');
+      expect(notification.noteDraft?.files, isEmpty);
+    });
+
+    test('round-trips every schema-derived notification payload', () {
+      for (final notification in notifications) {
+        expect(
+          MisskeyNotification.fromJson(notification.toJson()),
+          notification,
+          reason: notification.type.name,
+        );
+      }
+    });
+  });
 }


### PR DESCRIPTION
## 概要

- `MisskeyNotification` に `exportedEntity`、`fileId`、`invitation`、`noteDraft` を追加
- export対象を未知値フォールバック付きenumとして型付け
- `MisskeyNoteDraft` に `user`、`files`、`channel`、`renote`、`reply` を追加
- 上流の部分的なdraft channel応答に合わせて `MisskeyNoteDraftChannel` を新設
- Freezed/json_serializable生成物、fixtureベーステスト、全通知payloadのround-tripを追加

## Fixtureの境界

対象3通知のlive payloadは再採取していません。このためfixtureはMisskey公式develop `0b49119a3fb93e7be3a611831d64a1fcbb78e44e` のschemaから作成し、`liveServerCaptured: false`、参照commit、参照schemaをfixture内に明記しています。実際の通知配送とlive payloadは未検証です。

## レビュー

別担当の独立レビューで、初版のinline synthetic JSONがIssueのfixture要件を満たさない点と通知round-trip不足が指摘されました。schema由来の専用fixture、provenance、完全な招待payload、3通知すべてのround-tripを追加し、生成物再現を含め再レビュー承認済みです。

## 検証

- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm dart analyze --fatal-infos`
- `fvm dart run build_runner build` + 生成差分なし
- `fvm dart test --exclude-tags e2e`: 582件成功
- `fvm dart pub publish --dry-run`: warning 0
- 新payloadは公式schema由来fixture/round-tripで検証（live payloadの再採取は未実施）

Closes #19
Closes #20