### PR TITLE
feat: エンドポイント機能検出を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added cached runtime endpoint capability detection through `MetaApi.isEndpointAvailable()` and `MetaApi.getEndpoints(refresh: ...)`, with refresh support, in-flight request deduplication, deduplicated results, and compatibility guidance in all six READMEs (issue #41)
+
+### Changed
+
+- Added the explicit `MetaApi.hasMetaKey()` name for metadata key-presence checks and deprecated the ambiguous `supports()` alias; key presence does not interpret a boolean metadata value or indicate endpoint availability (issue #41)
+- **Breaking:** `MetaApi.getEndpoints()` now returns an unmodifiable list instead of a mutable list so callers cannot mutate a value that represents the cached endpoint snapshot (issue #41)
+
 ## [1.0.0-beta.8] - 2026-08-25
 
 ### Changed

--- a/README.de.md
+++ b/README.de.md
@@ -89,6 +89,24 @@ void main() async {
 | `streaming` | Echtzeit-Timelines, Benachrichtigungen und Updates erfasster Notes |
 | `users` | Benutzersuche, Listen, Beziehungen, Erfolge |
 
+## Serverkompatibilität
+
+Server können eine ältere Misskey-Version oder einen Fork mit einer abweichenden API-Oberfläche verwenden. Bevorzugen Sie die Laufzeitauflistung der Endpunkte gegenüber einem Vergleich von `Meta.version`: Versionsangaben von Forks sind nicht unbedingt mit Misskey-Releases vergleichbar, während `/api/endpoints` die vom Server tatsächlich angebotenen APIs meldet.
+
+```dart
+final canCreateDrafts = await client.meta.isEndpointAvailable(
+  endpoint: 'notes/drafts/create', // Ohne /api/-Präfix.
+);
+
+if (canCreateDrafts) {
+  // Entwurfsfunktion anzeigen oder aufrufen.
+}
+```
+
+Die Endpunktliste wird im Arbeitsspeicher zwischengespeichert. Übergeben Sie nach einem Server-Upgrade oder für einen aktuellen Stand `refresh: true` an `isEndpointAvailable()` oder `getEndpoints()`. Die Auflistung ist nur ein Hinweis vor dem Aufruf und keine Garantie: Der Server kann sich nach der Prüfung ändern, daher muss beim Endpunktaufruf weiterhin `MisskeyNotFoundException` behandelt werden. Wenn `/api/endpoints` auf einem Fork nicht verfügbar ist oder fehlschlägt, rufen Sie die gewünschte API direkt auf und behandeln Sie deren 404-Antwort. Eine 404-Antwort allein kann mehrdeutig sein: Entweder fehlt der Endpunkt oder die Ressource.
+
+`hasMetaKey('features.x')` prüft nur, ob ein Metadaten-Schlüssel vorhanden ist. Die Methode gibt auch dann `true` zurück, wenn dessen Wert `false` ist, und ersetzt daher keine Endpunkterkennung.
+
 ## Streaming API
 
 Die verzögert erstellte Verbindung `client.streaming` verwendet Server, Token-Provider und Logger des Clients gemeinsam. Abonnieren Sie einen typisierten `MisskeyStreamingChannel` und wählen Sie die passende Ebene: dekodierte `notes` und `notifications`, typisierte `events` oder verlustfreie `messages`.

--- a/README.fr.md
+++ b/README.fr.md
@@ -89,6 +89,24 @@ void main() async {
 | `streaming` | Fils d'actualité, notifications et mises à jour de Notes capturées en temps réel |
 | `users` | Recherche d'utilisateurs, listes, relations, succès |
 
+## Compatibilité des serveurs
+
+Un serveur peut utiliser une ancienne version de Misskey ou un fork dont la surface d'API diffère. Préférez l'énumération des points de terminaison à l'exécution plutôt que la comparaison de `Meta.version` : les versions des forks ne sont pas nécessairement comparables aux versions de Misskey, tandis que `/api/endpoints` indique les API réellement annoncées par le serveur.
+
+```dart
+final canCreateDrafts = await client.meta.isEndpointAvailable(
+  endpoint: 'notes/drafts/create', // Sans préfixe /api/.
+);
+
+if (canCreateDrafts) {
+  // Afficher ou appeler la fonctionnalité de brouillons.
+}
+```
+
+La liste des points de terminaison est mise en cache en mémoire. Passez `refresh: true` à `isEndpointAvailable()` ou `getEndpoints()` après une mise à niveau du serveur ou pour obtenir un nouvel instantané. Cette énumération est une indication préalable, pas une garantie : le serveur peut changer après la vérification, donc gérez toujours `MisskeyNotFoundException` lors de l'appel. Si `/api/endpoints` n'est pas disponible ou échoue sur un fork, appelez directement l'API souhaitée et gérez sa réponse 404 ; une 404 seule peut être ambiguë entre un point de terminaison absent et une ressource absente.
+
+`hasMetaKey('features.x')` vérifie uniquement la présence d'une clé de métadonnées. Cette méthode renvoie `true` même si la valeur est `false` et ne doit donc pas remplacer la détection des points de terminaison.
+
 ## API Streaming
 
 La connexion `client.streaming`, créée à la demande, partage le serveur, le fournisseur de jeton et le logger du client. Abonnez-vous avec un `MisskeyStreamingChannel` typé et choisissez le niveau adapté : `notes` et `notifications` décodées, `events` typés ou `messages` sans perte d'information.

--- a/README.ja.md
+++ b/README.ja.md
@@ -88,6 +88,24 @@ void main() async {
 | `streaming` | リアルタイムのタイムライン、通知、キャプチャしたノートの更新 |
 | `users` | ユーザー検索、リスト、関係、アチーブメント |
 
+## サーバー互換性
+
+接続先は古い Misskey のままの場合や、API 構成が異なるフォークの場合があります。`Meta.version` の比較より、実行時のエンドポイント列挙を優先してください。フォークのバージョン文字列は Misskey のリリースと比較できるとは限りませんが、`/api/endpoints` はそのサーバーが実際に公開している API を示します。
+
+```dart
+final canCreateDrafts = await client.meta.isEndpointAvailable(
+  endpoint: 'notes/drafts/create', // /api/ は付けません。
+);
+
+if (canCreateDrafts) {
+  // 下書き機能を表示または呼び出します。
+}
+```
+
+エンドポイント一覧はメモリにキャッシュされます。サーバー更新後や最新状態が必要な場合は `isEndpointAvailable()` または `getEndpoints()` に `refresh: true` を指定してください。列挙結果は事前判定用のスナップショットであり、呼び出し成功を保証しません。判定後にサーバーが変化する可能性があるため、実際の呼び出しでは引き続き `MisskeyNotFoundException` を処理してください。フォークで `/api/endpoints` 自体が利用できない、または失敗する場合は、目的の API を直接呼び出して 404 を処理します。ただし、404 だけでは「エンドポイントがない」のか「リソースがない」のか区別できない場合があります。
+
+`hasMetaKey('features.x')` はメタデータのキーが存在するかだけを確認します。値が `false` でも `true` を返すため、エンドポイント判定の代わりには使用しないでください。
+
 ## Streaming API
 
 遅延生成される `client.streaming` 接続は、クライアントのサーバー、トークンプロバイダー、ロガーを共有します。型付きの `MisskeyStreamingChannel` で購読し、用途に応じてデコード済みの `notes` / `notifications`、型付きの `events`、または情報を保持した `messages` を利用できます。

--- a/README.ko.md
+++ b/README.ko.md
@@ -89,6 +89,24 @@ void main() async {
 | `streaming` | 실시간 타임라인, 알림 및 캡처한 노트 업데이트 |
 | `users` | 사용자 검색, 리스트, 관계, 업적 |
 
+## 서버 호환성
+
+서버가 이전 Misskey 버전을 사용하거나 API 구성이 다른 포크를 실행할 수 있습니다. `Meta.version` 비교보다 런타임 엔드포인트 열거를 우선하세요. 포크의 버전 문자열은 Misskey 릴리스와 직접 비교할 수 없는 경우가 있지만, `/api/endpoints`는 해당 서버가 실제로 제공한다고 알리는 API를 반환합니다.
+
+```dart
+final canCreateDrafts = await client.meta.isEndpointAvailable(
+  endpoint: 'notes/drafts/create', // /api/ 접두사를 붙이지 않습니다.
+);
+
+if (canCreateDrafts) {
+  // 초안 기능을 표시하거나 호출합니다.
+}
+```
+
+엔드포인트 목록은 메모리에 캐시됩니다. 서버 업그레이드 후 또는 최신 스냅샷이 필요할 때 `isEndpointAvailable()`이나 `getEndpoints()`에 `refresh: true`를 전달하세요. 열거 결과는 사전 확인용 힌트일 뿐 성공을 보장하지 않습니다. 확인 후 서버가 바뀔 수 있으므로 실제 호출에서도 `MisskeyNotFoundException`을 처리해야 합니다. 포크에서 `/api/endpoints` 자체를 사용할 수 없거나 요청이 실패하면 대상 API를 직접 호출하고 404를 처리하세요. 404만으로는 엔드포인트 부재와 리소스 부재를 구분하지 못할 수 있습니다.
+
+`hasMetaKey('features.x')`는 메타데이터 키의 존재 여부만 확인합니다. 값이 `false`여도 `true`를 반환하므로 엔드포인트 감지를 대신하는 용도로 사용하면 안 됩니다.
+
 ## Streaming API
 
 지연 생성되는 `client.streaming` 연결은 클라이언트의 서버, 토큰 제공자, 로거를 공유합니다. 타입 지정 `MisskeyStreamingChannel`로 구독하고 애플리케이션에 맞게 디코딩된 `notes` / `notifications`, 타입 지정 `events`, 또는 정보를 보존하는 `messages`를 선택하세요.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,24 @@ void main() async {
 | `streaming` | Real-time timelines, notifications, and captured note updates |
 | `users` | User search, lists, relations, achievements |
 
+## Server compatibility
+
+Servers can lag behind current Misskey or run a fork with a different API surface. Prefer runtime endpoint enumeration over comparing `Meta.version`: fork version strings are not necessarily comparable with Misskey releases, while `/api/endpoints` reports what that server actually advertises.
+
+```dart
+final canCreateDrafts = await client.meta.isEndpointAvailable(
+  endpoint: 'notes/drafts/create', // No /api/ prefix.
+);
+
+if (canCreateDrafts) {
+  // Show or call the draft feature.
+}
+```
+
+The endpoint list is cached in memory. Pass `refresh: true` to `isEndpointAvailable()` or `getEndpoints()` after a server upgrade or when you need a fresh snapshot. Enumeration is a preflight hint, not a guarantee: the server can change after the check, so still handle `MisskeyNotFoundException` when calling the endpoint. If `/api/endpoints` itself is unavailable or fails on a fork, fall back to calling the desired API and handling its 404; a 404 alone may be ambiguous between an absent endpoint and an absent resource.
+
+`hasMetaKey('features.x')` only checks whether a metadata key exists. It returns `true` even when that key's value is `false`, so do not use metadata key presence as a substitute for endpoint detection.
+
 ## Streaming API
 
 The lazily created `client.streaming` connection shares the client's server, token provider, and logger. Subscribe with a typed `MisskeyStreamingChannel` and choose the level that fits your application: decoded `notes` and `notifications`, typed `events`, or lossless `messages`.

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -89,6 +89,24 @@ void main() async {
 | `streaming` | 实时时间线、通知和已捕获帖子的更新 |
 | `users` | 用户搜索、列表、关系、成就 |
 
+## 服务器兼容性
+
+服务器可能仍在运行旧版 Misskey，也可能使用 API 表面不同的分支版本。请优先在运行时枚举端点，而不是比较 `Meta.version`：分支版本字符串未必能与 Misskey 版本直接比较，而 `/api/endpoints` 会报告该服务器实际公开的 API。
+
+```dart
+final canCreateDrafts = await client.meta.isEndpointAvailable(
+  endpoint: 'notes/drafts/create', // 不要添加 /api/ 前缀。
+);
+
+if (canCreateDrafts) {
+  // 显示或调用草稿功能。
+}
+```
+
+端点列表会缓存在内存中。服务器升级后或需要最新快照时，请向 `isEndpointAvailable()` 或 `getEndpoints()` 传入 `refresh: true`。枚举结果只是调用前的提示，并不保证后续调用成功；检查后服务器仍可能发生变化，因此调用端点时仍应处理 `MisskeyNotFoundException`。如果某个分支不支持 `/api/endpoints` 或该请求失败，请直接调用目标 API 并处理其 404；仅凭 404 可能无法区分“端点不存在”和“资源不存在”。
+
+`hasMetaKey('features.x')` 只检查元数据键是否存在。即使该键的值为 `false`，它也会返回 `true`，因此不要用元数据键存在性代替端点检测。
+
 ## Streaming API
 
 延迟创建的 `client.streaming` 连接会共享客户端的服务器、令牌提供器和日志记录器。使用强类型 `MisskeyStreamingChannel` 进行订阅，并按应用需求选择已解码的 `notes` / `notifications`、强类型 `events` 或保留完整信息的 `messages`。

--- a/docs/docs/api/server.md
+++ b/docs/docs/api/server.md
@@ -31,20 +31,17 @@ Pass `detail: false` for a lightweight response (equivalent to `MetaLite`):
 final lite = await client.meta.getMeta(detail: false);
 ```
 
-### Feature detection
+### Metadata key presence
 
-Call `getMeta()` at least once before using `supports()`. It checks for a key
-in the raw response using a dot-notation path:
+Call `getMeta()` at least once before using `hasMetaKey()`. It only checks for a
+key in the raw response using a dot-notation path; it does not interpret the
+value, so a boolean value of `false` still counts as present:
 
 ```dart
 await client.meta.getMeta();
 
-if (client.meta.supports('features.miauth')) {
-  // MiAuth is available on this server
-}
-
-if (client.meta.supports('policies.canInvite')) {
-  // Invite feature is enabled
+if (client.meta.hasMetaKey('features.miauth')) {
+  // The response contains this key; inspect its value to determine enablement.
 }
 ```
 
@@ -71,6 +68,11 @@ final timestamp = await client.meta.ping();
 // All endpoint names
 final endpoints = await client.meta.getEndpoints();
 
+// Recommended preflight check for APIs added in newer server versions
+final canCreateDrafts = await client.meta.isEndpointAvailable(
+  endpoint: 'notes/drafts/create',
+);
+
 // Parameters for a specific endpoint
 final info = await client.meta.getEndpoint(endpoint: 'notes/create');
 if (info != null) {
@@ -79,6 +81,12 @@ if (info != null) {
   }
 }
 ```
+
+Endpoint enumeration is cached; pass `refresh: true` after a server upgrade.
+Prefer it over comparing `Meta.version`, especially for forks with independent
+version strings. It is only a snapshot, so still handle
+`MisskeyNotFoundException` on the actual call. If `/api/endpoints` is itself
+unavailable, call the desired API and handle its potentially ambiguous 404.
 
 ### Custom emoji
 

--- a/docs/i18n/de/docusaurus-plugin-content-docs/current/api/server.md
+++ b/docs/i18n/de/docusaurus-plugin-content-docs/current/api/server.md
@@ -31,19 +31,15 @@ Uebergeben Sie `detail: false` fuer eine kompakte Antwort (entspricht `MetaLite`
 final lite = await client.meta.getMeta(detail: false);
 ```
 
-### Funktionserkennung
+### Vorhandensein von Metadaten-Schluesseln
 
-Rufen Sie `getMeta()` mindestens einmal auf, bevor Sie `supports()` verwenden. Die Methode prueft einen Schluessel in der Rohantwort mithilfe eines Punktnotationspfads:
+Rufen Sie `getMeta()` mindestens einmal auf, bevor Sie `hasMetaKey()` verwenden. Die Methode prueft nur, ob ein Schluesselpfad in der Rohantwort vorhanden ist. Der Wert wird nicht interpretiert; auch ein boolescher Wert `false` zaehlt als vorhanden:
 
 ```dart
 await client.meta.getMeta();
 
-if (client.meta.supports('features.miauth')) {
-  // MiAuth ist auf diesem Server verfuegbar
-}
-
-if (client.meta.supports('policies.canInvite')) {
-  // Einladefunktion ist aktiviert
+if (client.meta.hasMetaKey('features.miauth')) {
+  // Der Schluessel ist vorhanden; pruefen Sie den Wert fuer die Aktivierung.
 }
 ```
 
@@ -70,6 +66,11 @@ final timestamp = await client.meta.ping();
 // Alle Endpunktnamen
 final endpoints = await client.meta.getEndpoints();
 
+// Empfohlene Vorabpruefung fuer APIs neuerer Serverversionen
+final canCreateDrafts = await client.meta.isEndpointAvailable(
+  endpoint: 'notes/drafts/create',
+);
+
 // Parameter fuer einen bestimmten Endpunkt
 final info = await client.meta.getEndpoint(endpoint: 'notes/create');
 if (info != null) {
@@ -78,6 +79,8 @@ if (info != null) {
   }
 }
 ```
+
+Die Endpunktauflistung wird zwischengespeichert; uebergeben Sie nach einem Server-Upgrade `refresh: true`. Bevorzugen Sie besonders bei Forks mit eigenen Versionsangaben die Auflistung gegenueber einem Vergleich von `Meta.version`. Das Ergebnis ist nur eine Momentaufnahme, daher muss beim tatsaechlichen Aufruf weiterhin `MisskeyNotFoundException` behandelt werden. Ist `/api/endpoints` selbst nicht verfuegbar, rufen Sie die gewuenschte API auf und behandeln Sie die moeglicherweise mehrdeutige 404-Antwort.
 
 ### Benutzerdefinierte Emojis
 

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/api/server.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/api/server.md
@@ -31,19 +31,15 @@ Passez `detail: false` pour une réponse allégée (équivalent à `MetaLite`) :
 final lite = await client.meta.getMeta(detail: false);
 ```
 
-### Détection des fonctionnalités
+### Présence des clés de métadonnées
 
-Appelez `getMeta()` au moins une fois avant d'utiliser `supports()`. Cette méthode vérifie la présence d'une clé dans la réponse brute en utilisant une notation par points :
+Appelez `getMeta()` au moins une fois avant d'utiliser `hasMetaKey()`. Cette méthode vérifie uniquement la présence d'une clé dans la réponse brute avec une notation par points. Elle n'interprète pas la valeur : une valeur booléenne `false` compte toujours comme présente.
 
 ```dart
 await client.meta.getMeta();
 
-if (client.meta.supports('features.miauth')) {
-  // MiAuth is available on this server
-}
-
-if (client.meta.supports('policies.canInvite')) {
-  // Invite feature is enabled
+if (client.meta.hasMetaKey('features.miauth')) {
+  // La clé existe ; inspectez sa valeur pour déterminer l'activation.
 }
 ```
 
@@ -70,6 +66,11 @@ final timestamp = await client.meta.ping();
 // All endpoint names
 final endpoints = await client.meta.getEndpoints();
 
+// Vérification préalable recommandée pour les API ajoutées récemment
+final canCreateDrafts = await client.meta.isEndpointAvailable(
+  endpoint: 'notes/drafts/create',
+);
+
 // Parameters for a specific endpoint
 final info = await client.meta.getEndpoint(endpoint: 'notes/create');
 if (info != null) {
@@ -78,6 +79,8 @@ if (info != null) {
   }
 }
 ```
+
+L'énumération des points de terminaison est mise en cache ; passez `refresh: true` après une mise à niveau du serveur. Préférez-la à la comparaison de `Meta.version`, surtout pour les forks ayant leurs propres versions. Le résultat n'est qu'un instantané : gérez toujours `MisskeyNotFoundException` lors de l'appel réel. Si `/api/endpoints` n'est pas disponible, appelez directement l'API souhaitée et gérez sa réponse 404 potentiellement ambiguë.
 
 ### Emojis personnalisés
 

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/api/server.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/api/server.md
@@ -31,20 +31,16 @@ final fresh = await client.meta.getMeta(refresh: true);
 final lite = await client.meta.getMeta(detail: false);
 ```
 
-### 機能検出
+### メタデータキーの存在確認
 
-`supports()` を呼ぶ前に `getMeta()` を少なくとも一度呼び出してください。
-ドット記法のキーパスでレスポンスのフィールドを確認します。
+`hasMetaKey()` を呼ぶ前に `getMeta()` を少なくとも一度呼び出してください。
+ドット記法のキーパスでレスポンスのフィールドが存在するかだけを確認します。値は解釈しないため、真偽値が `false` でもキーがあれば `true` を返します。
 
 ```dart
 await client.meta.getMeta();
 
-if (client.meta.supports('features.miauth')) {
-  // MiAuth が利用可能
-}
-
-if (client.meta.supports('policies.canInvite')) {
-  // 招待機能が有効
+if (client.meta.hasMetaKey('features.miauth')) {
+  // キーが存在します。有効かどうかは値を確認してください。
 }
 ```
 
@@ -71,6 +67,11 @@ final timestamp = await client.meta.ping();
 // 全エンドポイント名の一覧
 final endpoints = await client.meta.getEndpoints();
 
+// 新しいサーバーバージョンで追加されたAPIの推奨事前判定
+final canCreateDrafts = await client.meta.isEndpointAvailable(
+  endpoint: 'notes/drafts/create',
+);
+
 // 特定エンドポイントのパラメーター情報
 final info = await client.meta.getEndpoint(endpoint: 'notes/create');
 if (info != null) {
@@ -79,6 +80,8 @@ if (info != null) {
   }
 }
 ```
+
+エンドポイント列挙はキャッシュされます。サーバー更新後は `refresh: true` を指定してください。独自のバージョン文字列を持つフォークもあるため、`Meta.version` の比較より列挙を優先します。結果はスナップショットにすぎないので、実際の呼び出しでは `MisskeyNotFoundException` も処理してください。`/api/endpoints` 自体が利用できない場合は目的の API を呼び出して、意味が曖昧な可能性がある 404 を処理します。
 
 ### カスタム絵文字
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/server.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/server.md
@@ -31,19 +31,15 @@ final fresh = await client.meta.getMeta(refresh: true);
 final lite = await client.meta.getMeta(detail: false);
 ```
 
-### 기능 감지
+### 메타데이터 키 존재 여부
 
-`supports()`를 사용하기 전에 `getMeta()`를 최소 한 번 호출해야 합니다. 점 표기법 경로를 사용하여 원시 응답의 키를 확인합니다:
+`hasMetaKey()`를 사용하기 전에 `getMeta()`를 최소 한 번 호출해야 합니다. 점 표기법 경로로 원시 응답에 키가 있는지만 확인합니다. 값은 해석하지 않으므로 불리언 값이 `false`여도 키가 있으면 `true`를 반환합니다:
 
 ```dart
 await client.meta.getMeta();
 
-if (client.meta.supports('features.miauth')) {
-  // 이 서버에서 MiAuth를 사용할 수 있습니다
-}
-
-if (client.meta.supports('policies.canInvite')) {
-  // 초대 기능이 활성화되어 있습니다
+if (client.meta.hasMetaKey('features.miauth')) {
+  // 키가 있습니다. 활성화 여부는 값을 확인하세요.
 }
 ```
 
@@ -70,6 +66,11 @@ final timestamp = await client.meta.ping();
 // 모든 엔드포인트 이름
 final endpoints = await client.meta.getEndpoints();
 
+// 최신 서버 버전에 추가된 API의 권장 사전 확인
+final canCreateDrafts = await client.meta.isEndpointAvailable(
+  endpoint: 'notes/drafts/create',
+);
+
 // 특정 엔드포인트의 파라미터
 final info = await client.meta.getEndpoint(endpoint: 'notes/create');
 if (info != null) {
@@ -78,6 +79,8 @@ if (info != null) {
   }
 }
 ```
+
+엔드포인트 열거 결과는 캐시됩니다. 서버 업그레이드 후에는 `refresh: true`를 전달하세요. 자체 버전 문자열을 사용하는 포크가 있으므로 `Meta.version` 비교보다 열거를 우선합니다. 결과는 스냅샷일 뿐이므로 실제 호출에서는 계속 `MisskeyNotFoundException`을 처리해야 합니다. `/api/endpoints` 자체를 사용할 수 없다면 대상 API를 직접 호출하고 의미가 모호할 수 있는 404를 처리하세요.
 
 ### 커스텀 이모지
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/api/server.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/api/server.md
@@ -31,19 +31,15 @@ final fresh = await client.meta.getMeta(refresh: true);
 final lite = await client.meta.getMeta(detail: false);
 ```
 
-### 功能检测
+### 元数据键存在性
 
-在使用 `supports()` 前至少需要调用一次 `getMeta()`。它通过点分隔路径检查原始响应中的键：
+在使用 `hasMetaKey()` 前至少调用一次 `getMeta()`。它仅通过点分隔路径检查原始响应中是否存在键，不解释字段值；即使布尔值为 `false`，只要键存在也会返回 `true`：
 
 ```dart
 await client.meta.getMeta();
 
-if (client.meta.supports('features.miauth')) {
-  // 该服务器支持 MiAuth
-}
-
-if (client.meta.supports('policies.canInvite')) {
-  // 邀请功能已启用
+if (client.meta.hasMetaKey('features.miauth')) {
+  // 该键存在；请检查其值来判断是否启用。
 }
 ```
 
@@ -70,6 +66,11 @@ final timestamp = await client.meta.ping();
 // 所有端点名称
 final endpoints = await client.meta.getEndpoints();
 
+// 对较新服务器版本新增 API 的推荐预检查
+final canCreateDrafts = await client.meta.isEndpointAvailable(
+  endpoint: 'notes/drafts/create',
+);
+
 // 特定端点的参数
 final info = await client.meta.getEndpoint(endpoint: 'notes/create');
 if (info != null) {
@@ -78,6 +79,8 @@ if (info != null) {
   }
 }
 ```
+
+端点枚举结果会被缓存；服务器升级后请传入 `refresh: true`。特别是对于使用独立版本字符串的分支，应优先枚举端点而不是比较 `Meta.version`。结果只是快照，因此实际调用时仍需处理 `MisskeyNotFoundException`。如果 `/api/endpoints` 本身不可用，请直接调用目标 API 并处理含义可能不明确的 404。
 
 ### 自定义表情
 

--- a/example/example.dart
+++ b/example/example.dart
@@ -21,9 +21,9 @@ void main() async {
   print('Server: ${meta.name}');
   print('Version: ${meta.version}');
 
-  // Feature detection via dot-notation key path
-  if (client.meta.supports('policies.canInvite')) {
-    print('This server allows invitations.');
+  // 古いサーバーに存在しない可能性があるAPIは、エンドポイント一覧で判定する。
+  if (await client.meta.isEndpointAvailable(endpoint: 'notes/drafts/create')) {
+    print('This server provides note drafts.');
   }
 
   // -------------------------------------------------------

--- a/lib/src/api/meta_api.dart
+++ b/lib/src/api/meta_api.dart
@@ -15,8 +15,8 @@ import '../models/server/server_info.dart';
 
 /// Provides server metadata API endpoints (`/api/meta`).
 ///
-/// Caches results in memory so that subsequent calls skip the network request.
-/// Use [supports] to detect server capabilities via dot-notation key paths.
+/// Caches metadata and endpoint enumeration results in memory so that
+/// subsequent calls skip the network request.
 class MetaApi {
   /// Creates an instance that operates the metadata API using [http].
   MetaApi({required this.http});
@@ -26,6 +26,8 @@ class MetaApi {
   final MisskeyHttp http;
 
   Meta? _cached;
+  Set<String>? _cachedEndpoints;
+  Future<List<String>>? _endpointsRequest;
 
   /// Retrieves server metadata (`/api/meta`).
   ///
@@ -89,13 +91,75 @@ class MetaApi {
   }
 
   /// Retrieves all available endpoint names (`/api/endpoints`).
-  Future<List<String>> getEndpoints() async {
+  ///
+  /// Set [refresh] to `true` to bypass a completed cache entry. Concurrent
+  /// requests share the same in-flight HTTP request, including refreshes.
+  /// Duplicate endpoint names returned by the server are removed and the
+  /// returned list cannot be modified.
+  ///
+  /// A failed request is not cached. If a refresh fails, the previous cache
+  /// entry remains available to later calls without [refresh].
+  Future<List<String>> getEndpoints({bool refresh = false}) async {
+    final pending = _endpointsRequest;
+    if (pending != null) return pending;
+    if (!refresh && _cachedEndpoints != null) {
+      return List<String>.unmodifiable(_cachedEndpoints!);
+    }
+
+    final request = _fetchEndpoints();
+    _endpointsRequest = request;
+    try {
+      return await request;
+    } finally {
+      if (identical(_endpointsRequest, request)) {
+        _endpointsRequest = null;
+      }
+    }
+  }
+
+  Future<List<String>> _fetchEndpoints() async {
     final res = await http.send<List<dynamic>>(
       '/endpoints',
       body: const <String, dynamic>{},
       options: const RequestOptions(authMode: AuthMode.none, idempotent: true),
     );
-    return res.cast<String>();
+    final endpoints = <String>{};
+    for (final value in res) {
+      if (value is! String || !_isValidEndpointName(value)) {
+        throw const FormatException(
+          'The /api/endpoints response contains an invalid endpoint name.',
+        );
+      }
+      endpoints.add(value);
+    }
+    _cachedEndpoints = Set<String>.unmodifiable(endpoints);
+    return List<String>.unmodifiable(endpoints);
+  }
+
+  /// Whether [endpoint] is advertised by the server's `/api/endpoints` list.
+  ///
+  /// Use the canonical endpoint name without the `/api/` prefix, for example
+  /// `notes/drafts/create`. Invalid names throw [ArgumentError].
+  ///
+  /// This is the recommended preflight check for endpoints that may be absent
+  /// on older Misskey versions or forks. It is still a snapshot: callers must
+  /// handle an HTTP 404 when invoking the endpoint, especially if the server
+  /// configuration or software changes after this check.
+  ///
+  /// Set [refresh] to `true` to refresh the endpoint cache first.
+  Future<bool> isEndpointAvailable({
+    required String endpoint,
+    bool refresh = false,
+  }) async {
+    if (!_isValidEndpointName(endpoint)) {
+      throw ArgumentError.value(
+        endpoint,
+        'endpoint',
+        'Use a canonical endpoint name such as notes/drafts/create.',
+      );
+    }
+    final endpoints = await getEndpoints(refresh: refresh);
+    return endpoints.contains(endpoint);
   }
 
   /// Retrieves parameter information for a specific endpoint (`/api/endpoint`).
@@ -198,17 +262,21 @@ class MetaApi {
         .toList();
   }
 
-  /// Performs a simple capability check against cached metadata.
+  /// Whether a key path exists in cached metadata.
   ///
   /// Specify a dot-separated key path in [keyPath] (e.g., `"features.miauth"`)
   /// and returns `true` if that key exists in [Meta.raw].
+  /// The value at that path is not interpreted, so a boolean value of `false`
+  /// still returns `true`.
   /// Always returns `false` if [getMeta] has not been called yet.
-  bool supports(String keyPath) {
+  bool hasMetaKey(String keyPath) {
     final meta = _cached;
     if (meta == null) return false;
+    if (keyPath.isEmpty) return false;
     final parts = keyPath.split('.');
     dynamic cursor = meta.raw.json;
     for (final p in parts) {
+      if (p.isEmpty) return false;
       if (cursor is Map && cursor.containsKey(p)) {
         cursor = cursor[p];
       } else {
@@ -216,5 +284,24 @@ class MetaApi {
       }
     }
     return true;
+  }
+
+  /// Whether a key path exists in cached metadata.
+  ///
+  /// This checks key presence only. It does not interpret the stored value as
+  /// a capability flag; use [isEndpointAvailable] for endpoint support.
+  @Deprecated(
+    'Use hasMetaKey for metadata key presence or isEndpointAvailable for '
+    'endpoint support.',
+  )
+  bool supports(String keyPath) => hasMetaKey(keyPath);
+
+  static bool _isValidEndpointName(String endpoint) {
+    return endpoint.isNotEmpty &&
+        endpoint.trim() == endpoint &&
+        !endpoint.startsWith('/') &&
+        !endpoint.endsWith('/') &&
+        !endpoint.contains('//') &&
+        !endpoint.contains(RegExp(r'[\s?#]'));
   }
 }

--- a/test/api/meta_api_test.dart
+++ b/test/api/meta_api_test.dart
@@ -1,0 +1,285 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:misskey_client/misskey_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('MetaApi endpoint capabilities', () {
+    test('accepts the endpoint list captured from a real server', () async {
+      final fixture = jsonDecode(
+        File('test/fixtures/endpoints.json').readAsStringSync(),
+      );
+      final adapter = _QueuedHttpClientAdapter([_Response.ok(fixture)]);
+      final client = _client(adapter);
+
+      final endpoints = await client.meta.getEndpoints();
+
+      expect(endpoints, contains('notes/drafts/create'));
+      expect(
+        await client.meta.isEndpointAvailable(
+          endpoint: 'users/get-following-users-by-birthday',
+        ),
+        isTrue,
+      );
+      expect(adapter.requestCount, 1);
+
+      await client.dispose();
+    });
+
+    test('caches a deduplicated and immutable endpoint list', () async {
+      final adapter = _QueuedHttpClientAdapter([
+        _Response.ok(['notes/create', 'notes/create', 'users/show']),
+      ]);
+      final client = _client(adapter);
+
+      final first = await client.meta.getEndpoints();
+      final second = await client.meta.getEndpoints();
+
+      expect(first, ['notes/create', 'users/show']);
+      expect(second, first);
+      expect(adapter.requestCount, 1);
+      expect(() => first.add('notes/delete'), throwsUnsupportedError);
+
+      await client.dispose();
+    });
+
+    test('refresh replaces a completed cache entry', () async {
+      final adapter = _QueuedHttpClientAdapter([
+        _Response.ok(['notes/create']),
+        _Response.ok(['notes/create', 'notes/drafts/create']),
+      ]);
+      final client = _client(adapter);
+
+      expect(
+        await client.meta.isEndpointAvailable(endpoint: 'notes/drafts/create'),
+        isFalse,
+      );
+      expect(
+        await client.meta.isEndpointAvailable(
+          endpoint: 'notes/drafts/create',
+          refresh: true,
+        ),
+        isTrue,
+      );
+      expect(adapter.requestCount, 2);
+
+      await client.dispose();
+    });
+
+    test('shares one in-flight request between concurrent callers', () async {
+      final gate = Completer<void>();
+      final adapter = _QueuedHttpClientAdapter([
+        _Response.ok(['notes/create']),
+      ], gate: gate);
+      final client = _client(adapter);
+
+      final first = client.meta.getEndpoints();
+      final second = client.meta.getEndpoints(refresh: true);
+      await adapter.started.future;
+
+      expect(adapter.requestCount, 1);
+      gate.complete();
+      expect(await first, ['notes/create']);
+      expect(await second, ['notes/create']);
+
+      await client.dispose();
+    });
+
+    test(
+      'regular caller shares an in-flight refresh instead of stale cache',
+      () async {
+        final adapter = _QueuedHttpClientAdapter([
+          _Response.ok(['notes/create']),
+          _Response.ok(['notes/create', 'notes/drafts/create']),
+        ]);
+        final client = _client(adapter);
+        expect(await client.meta.getEndpoints(), ['notes/create']);
+
+        final refreshGate = Completer<void>();
+        final refreshStarted = Completer<void>();
+        adapter
+          ..gate = refreshGate
+          ..nextStarted = refreshStarted;
+
+        final refresh = client.meta.getEndpoints(refresh: true);
+        await refreshStarted.future;
+        final regular = client.meta.getEndpoints();
+
+        expect(adapter.requestCount, 2);
+        refreshGate.complete();
+        expect(await refresh, ['notes/create', 'notes/drafts/create']);
+        expect(await regular, ['notes/create', 'notes/drafts/create']);
+
+        await client.dispose();
+      },
+    );
+
+    test(
+      'failed refresh propagates and preserves the previous cache',
+      () async {
+        final adapter = _QueuedHttpClientAdapter([
+          _Response.ok(['notes/create']),
+          const _Response(statusCode: 500, body: {'error': 'temporary'}),
+        ]);
+        final client = _client(adapter);
+
+        expect(await client.meta.getEndpoints(), ['notes/create']);
+        await expectLater(
+          client.meta.getEndpoints(refresh: true),
+          throwsA(isA<MisskeyServerException>()),
+        );
+        expect(await client.meta.getEndpoints(), ['notes/create']);
+        expect(adapter.requestCount, 2);
+
+        await client.dispose();
+      },
+    );
+
+    test('failed initial request is not cached', () async {
+      final adapter = _QueuedHttpClientAdapter([
+        const _Response(statusCode: 500, body: {'error': 'temporary'}),
+        _Response.ok(['notes/create']),
+      ]);
+      final client = _client(adapter);
+
+      await expectLater(
+        client.meta.getEndpoints(),
+        throwsA(isA<MisskeyServerException>()),
+      );
+      expect(await client.meta.getEndpoints(), ['notes/create']);
+      expect(adapter.requestCount, 2);
+
+      await client.dispose();
+    });
+
+    test('does not turn an unavailable enumeration API into false', () async {
+      final adapter = _QueuedHttpClientAdapter([
+        const _Response(statusCode: 404, body: {'error': 'not found'}),
+      ]);
+      final client = _client(adapter);
+
+      await expectLater(
+        client.meta.isEndpointAvailable(endpoint: 'notes/drafts/create'),
+        throwsA(isA<MisskeyNotFoundException>()),
+      );
+      expect(adapter.requestCount, 1);
+
+      await client.dispose();
+    });
+
+    test('rejects malformed endpoint names from the server', () async {
+      final adapter = _QueuedHttpClientAdapter([
+        _Response.ok(['notes/create', '']),
+      ]);
+      final client = _client(adapter);
+
+      await expectLater(
+        client.meta.getEndpoints(),
+        throwsA(isA<FormatException>()),
+      );
+
+      await client.dispose();
+    });
+
+    test('rejects non-canonical lookup input without a request', () async {
+      final adapter = _QueuedHttpClientAdapter([]);
+      final client = _client(adapter);
+
+      for (final endpoint in [
+        '',
+        ' notes/create',
+        '/notes/create',
+        'notes/create/',
+        'notes//create',
+        'notes/create?draft=true',
+      ]) {
+        await expectLater(
+          client.meta.isEndpointAvailable(endpoint: endpoint),
+          throwsArgumentError,
+        );
+      }
+      expect(adapter.requestCount, 0);
+
+      await client.dispose();
+    });
+  });
+
+  group('MetaApi metadata key presence', () {
+    test('does not interpret a false value as unsupported', () async {
+      final meta = jsonDecode(
+        File('test/fixtures/meta.json').readAsStringSync(),
+      );
+      final adapter = _QueuedHttpClientAdapter([_Response.ok(meta)]);
+      final client = _client(adapter);
+
+      expect(client.meta.hasMetaKey('features.registration'), isFalse);
+      await client.meta.getMeta();
+      expect(client.meta.hasMetaKey('features.registration'), isTrue);
+      expect(client.meta.hasMetaKey('features.missing'), isFalse);
+      expect(client.meta.hasMetaKey('features..registration'), isFalse);
+
+      await client.dispose();
+    });
+  });
+}
+
+MisskeyClient _client(HttpClientAdapter adapter) {
+  return MisskeyClient(
+    config: MisskeyClientConfig(
+      baseUrl: Uri.parse('https://misskey.example.com'),
+      maxRetries: 1,
+    ),
+    httpClientAdapter: adapter,
+  );
+}
+
+final class _QueuedHttpClientAdapter implements HttpClientAdapter {
+  _QueuedHttpClientAdapter(this.responses, {this.gate});
+
+  final List<_Response> responses;
+  Completer<void>? gate;
+  Completer<void>? nextStarted;
+  final Completer<void> started = Completer<void>();
+  int requestCount = 0;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requestCount++;
+    if (!started.isCompleted) started.complete();
+    nextStarted?.complete();
+    nextStarted = null;
+    final requestGate = gate;
+    await requestGate?.future;
+    if (responses.isEmpty) {
+      throw StateError('No queued response for ${options.uri.path}');
+    }
+    final response = responses.removeAt(0);
+    return ResponseBody.fromString(
+      jsonEncode(response.body),
+      response.statusCode,
+      headers: {
+        Headers.contentTypeHeader: ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+final class _Response {
+  const _Response({required this.statusCode, required this.body});
+
+  _Response.ok(Object? body) : this(statusCode: 200, body: body);
+
+  final int statusCode;
+  final Object? body;
+}


### PR DESCRIPTION
## 概要

- `MetaApi.getEndpoints(refresh:)` にメモリキャッシュ、重複除去、in-flight共有を追加
- `MetaApi.isEndpointAvailable(endpoint:)` を追加し、古いサーバー・フォークでの事前判定を提供
- metadataのキー存在だけを見る処理を `hasMetaKey()` として明確化し、曖昧な `supports()` を非推奨化
- READMEとDocusaurus全6言語、exampleにserver compatibilityガイドを追加
- キャッシュ、refresh競合、失敗時旧cache保持、404伝播、不正入力、immutable返却を単体テストで固定

## レビュー

別担当の独立レビューで、キャッシュ済みrefresh中の通常呼出が旧cacheを返す競合、exampleのコメント言語、返却Listのimmutable化に対するBreaking記載不足が指摘されました。通常呼出も進行中refreshを共有するよう修正し、競合テスト・日本語コメント・Breaking記載を追加して再レビュー承認済みです。

## 検証

- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm dart analyze --fatal-infos`
- `fvm dart run build_runner build` + 生成差分なし
- `fvm dart test --exclude-tags e2e`: 582件成功
- `fvm dart pub publish --dry-run`: warning 0
- マージ判断の再現可能な根拠はfixture/単体テスト。/api/endpointsのlive観測はmaintainer-onlyの補助検証として別コメントに記録

Closes #41