### PR TITLE
feat: Admin一覧APIへ日付ページネーションを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Exposed schema-defined Unix-millisecond `sinceDate` / `untilDate` arguments on eight Admin list APIs covering abuse reports, ads, announcements, avatar decorations, drive files, local and remote emoji, and moderation logs. The current upstream avatar-decoration handler accepts but ignores its pagination arguments (issue #24)
+
 ## [1.0.0-beta.8] - 2026-08-25
 
 ### Changed

--- a/lib/src/api/admin/admin_abuse_reports_api.dart
+++ b/lib/src/api/admin/admin_abuse_reports_api.dart
@@ -19,14 +19,17 @@ class AdminAbuseReportsApi {
   /// Fetches abuse reports (`/api/admin/abuse-user-reports`).
   ///
   /// Use [limit] (1-100, default 10) to cap the number of results and
-  /// [sinceId] / [untilId] for cursor-based pagination. [state] filters
-  /// by resolution state (`resolved` or `unresolved`). [reporterOrigin]
-  /// and [targetUserOrigin] filter by origin (`combined`, `local`,
-  /// `remote`).
+  /// [sinceId] / [untilId] for cursor-based pagination. [sinceDate] /
+  /// [untilDate] paginate by Unix timestamp in milliseconds. [state]
+  /// filters by resolution state (`resolved` or `unresolved`).
+  /// [reporterOrigin] and [targetUserOrigin] filter by origin (`combined`,
+  /// `local`, `remote`).
   Future<List<MisskeyAbuseUserReport>> list({
     int? limit,
     String? sinceId,
     String? untilId,
+    int? sinceDate,
+    int? untilDate,
     String? state,
     String? reporterOrigin,
     String? targetUserOrigin,
@@ -37,6 +40,8 @@ class AdminAbuseReportsApi {
         'limit': ?limit,
         'sinceId': ?sinceId,
         'untilId': ?untilId,
+        'sinceDate': ?sinceDate,
+        'untilDate': ?untilDate,
         'state': ?state,
         'reporterOrigin': ?reporterOrigin,
         'targetUserOrigin': ?targetUserOrigin,

--- a/lib/src/api/admin/admin_ad_api.dart
+++ b/lib/src/api/admin/admin_ad_api.dart
@@ -53,13 +53,16 @@ class AdminAdApi {
   /// Fetches advertisements (`/api/admin/ad/list`).
   ///
   /// Use [limit] (1-100, default 10) to cap the number of results and
-  /// [sinceId] / [untilId] for cursor-based pagination. Set [publishing]
-  /// to `true` to list only currently published ads, or `false` for ads
-  /// that are not currently published.
+  /// [sinceId] / [untilId] for cursor-based pagination. [sinceDate] /
+  /// [untilDate] paginate by Unix timestamp in milliseconds. Set
+  /// [publishing] to `true` to list only currently published ads, or `false`
+  /// for ads that are not currently published.
   Future<List<MisskeyAd>> list({
     int? limit,
     String? sinceId,
     String? untilId,
+    int? sinceDate,
+    int? untilDate,
     bool? publishing,
   }) async {
     final res = await http.send<List<dynamic>>(
@@ -68,6 +71,8 @@ class AdminAdApi {
         'limit': ?limit,
         'sinceId': ?sinceId,
         'untilId': ?untilId,
+        'sinceDate': ?sinceDate,
+        'untilDate': ?untilDate,
         'publishing': ?publishing,
       },
       options: const RequestOptions(idempotent: true),

--- a/lib/src/api/admin/admin_announcements_api.dart
+++ b/lib/src/api/admin/admin_announcements_api.dart
@@ -53,13 +53,16 @@ class AdminAnnouncementsApi {
   /// Fetches announcements (`/api/admin/announcements/list`).
   ///
   /// Use [limit] (1-100, default 10) to cap the number of results and
-  /// [sinceId] / [untilId] for cursor-based pagination. [status] filters
-  /// by state (`all`, `active`, `archived`; default `active`). Pass
-  /// [userId] to fetch user-specific announcements.
+  /// [sinceId] / [untilId] for cursor-based pagination. [sinceDate] /
+  /// [untilDate] paginate by Unix timestamp in milliseconds. [status]
+  /// filters by state (`all`, `active`, `archived`; default `active`).
+  /// Pass [userId] to fetch user-specific announcements.
   Future<List<MisskeyAdminAnnouncement>> list({
     int? limit,
     String? sinceId,
     String? untilId,
+    int? sinceDate,
+    int? untilDate,
     String? userId,
     String? status,
   }) async {
@@ -69,6 +72,8 @@ class AdminAnnouncementsApi {
         'limit': ?limit,
         'sinceId': ?sinceId,
         'untilId': ?untilId,
+        'sinceDate': ?sinceDate,
+        'untilDate': ?untilDate,
         'userId': ?userId,
         'status': ?status,
       },

--- a/lib/src/api/admin/admin_api.dart
+++ b/lib/src/api/admin/admin_api.dart
@@ -263,12 +263,15 @@ class AdminApi {
   ///
   /// Requires moderator privileges. Use [limit] (1-100, default 10) to
   /// cap the number of results and [sinceId] / [untilId] for
-  /// cursor-based pagination. [type] filters by action type, [userId] by
-  /// the moderator who performed the action, and [search] by keyword.
+  /// cursor-based pagination. [sinceDate] / [untilDate] paginate by Unix
+  /// timestamp in milliseconds. [type] filters by action type, [userId]
+  /// by the moderator who performed the action, and [search] by keyword.
   Future<List<MisskeyModerationLog>> showModerationLogs({
     int? limit,
     String? sinceId,
     String? untilId,
+    int? sinceDate,
+    int? untilDate,
     String? type,
     String? userId,
     String? search,
@@ -279,6 +282,8 @@ class AdminApi {
         'limit': ?limit,
         'sinceId': ?sinceId,
         'untilId': ?untilId,
+        'sinceDate': ?sinceDate,
+        'untilDate': ?untilDate,
         'type': ?type,
         'userId': ?userId,
         'search': ?search,

--- a/lib/src/api/admin/admin_avatar_decorations_api.dart
+++ b/lib/src/api/admin/admin_avatar_decorations_api.dart
@@ -45,12 +45,20 @@ class AdminAvatarDecorationsApi {
   /// Fetches avatar decorations (`/api/admin/avatar-decorations/list`).
   ///
   /// Use [limit] (1-100, default 10) to cap the number of results and
-  /// [sinceId] / [untilId] for cursor-based pagination. Pass [userId] to
-  /// list only decorations available to that user.
+  /// [sinceId] / [untilId] for cursor-based pagination. [sinceDate] /
+  /// [untilDate] paginate by Unix timestamp in milliseconds. Pass [userId]
+  /// to list only decorations available to that user.
+  ///
+  /// The current upstream Misskey handler accepts these pagination parameters
+  /// in its schema but ignores them, so they do not presently affect results
+  /// on upstream Misskey. They remain available for compatible forks and
+  /// future upstream implementations.
   Future<List<MisskeyAdminAvatarDecoration>> list({
     int? limit,
     String? sinceId,
     String? untilId,
+    int? sinceDate,
+    int? untilDate,
     String? userId,
   }) async {
     final res = await http.send<List<dynamic>>(
@@ -59,6 +67,8 @@ class AdminAvatarDecorationsApi {
         'limit': ?limit,
         'sinceId': ?sinceId,
         'untilId': ?untilId,
+        'sinceDate': ?sinceDate,
+        'untilDate': ?untilDate,
         'userId': ?userId,
       },
       options: const RequestOptions(idempotent: true),

--- a/lib/src/api/admin/admin_drive_api.dart
+++ b/lib/src/api/admin/admin_drive_api.dart
@@ -16,13 +16,16 @@ class AdminDriveApi {
   /// Fetches drive files across all users (`/api/admin/drive/files`).
   ///
   /// Use [limit] (1-100, default 10) to cap the number of results and
-  /// [sinceId] / [untilId] for cursor-based pagination. [userId] filters
-  /// by owner, [type] by MIME type (e.g. `image/*`), [origin] by origin
-  /// (`combined`, `local`, `remote`), and [hostname] by remote host.
+  /// [sinceId] / [untilId] for cursor-based pagination. [sinceDate] /
+  /// [untilDate] paginate by Unix timestamp in milliseconds. [userId]
+  /// filters by owner, [type] by MIME type (e.g. `image/*`), [origin] by
+  /// origin (`combined`, `local`, `remote`), and [hostname] by remote host.
   Future<List<MisskeyDriveFile>> files({
     int? limit,
     String? sinceId,
     String? untilId,
+    int? sinceDate,
+    int? untilDate,
     String? userId,
     String? type,
     String? origin,
@@ -34,6 +37,8 @@ class AdminDriveApi {
         'limit': ?limit,
         'sinceId': ?sinceId,
         'untilId': ?untilId,
+        'sinceDate': ?sinceDate,
+        'untilDate': ?untilDate,
         'userId': ?userId,
         'type': ?type,
         'origin': ?origin,

--- a/lib/src/api/admin/admin_emoji_api.dart
+++ b/lib/src/api/admin/admin_emoji_api.dart
@@ -109,12 +109,15 @@ class AdminEmojiApi {
   ///
   /// Use [query] to filter by name, [limit] (1-100, default 10) to cap
   /// the number of results, and [sinceId] / [untilId] for cursor-based
-  /// pagination.
+  /// pagination. [sinceDate] / [untilDate] paginate by Unix timestamp in
+  /// milliseconds.
   Future<List<EmojiDetailed>> list({
     String? query,
     int? limit,
     String? sinceId,
     String? untilId,
+    int? sinceDate,
+    int? untilDate,
   }) async {
     final res = await http.send<List<dynamic>>(
       '/admin/emoji/list',
@@ -123,6 +126,8 @@ class AdminEmojiApi {
         'limit': ?limit,
         'sinceId': ?sinceId,
         'untilId': ?untilId,
+        'sinceDate': ?sinceDate,
+        'untilDate': ?untilDate,
       },
       options: const RequestOptions(idempotent: true),
     );
@@ -136,13 +141,16 @@ class AdminEmojiApi {
   ///
   /// Use [host] to filter by the remote host, [query] to filter by name,
   /// [limit] (1-100, default 10) to cap the number of results, and
-  /// [sinceId] / [untilId] for cursor-based pagination.
+  /// [sinceId] / [untilId] for cursor-based pagination. [sinceDate] /
+  /// [untilDate] paginate by Unix timestamp in milliseconds.
   Future<List<EmojiDetailed>> listRemote({
     String? query,
     String? host,
     int? limit,
     String? sinceId,
     String? untilId,
+    int? sinceDate,
+    int? untilDate,
   }) async {
     final res = await http.send<List<dynamic>>(
       '/admin/emoji/list-remote',
@@ -152,6 +160,8 @@ class AdminEmojiApi {
         'limit': ?limit,
         'sinceId': ?sinceId,
         'untilId': ?untilId,
+        'sinceDate': ?sinceDate,
+        'untilDate': ?untilDate,
       },
       options: const RequestOptions(idempotent: true),
     );

--- a/test/api/admin_date_pagination_test.dart
+++ b/test/api/admin_date_pagination_test.dart
@@ -1,0 +1,123 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:misskey_client/misskey_client.dart';
+import 'package:test/test.dart';
+
+const _adminListPaths = <String>[
+  '/api/admin/abuse-user-reports',
+  '/api/admin/ad/list',
+  '/api/admin/announcements/list',
+  '/api/admin/avatar-decorations/list',
+  '/api/admin/drive/files',
+  '/api/admin/emoji/list',
+  '/api/admin/emoji/list-remote',
+  '/api/admin/show-moderation-logs',
+];
+
+void main() {
+  test(
+    'all eight admin list APIs send Unix-millisecond date cursors',
+    () async {
+      const sinceDate = 1767225600123;
+      const untilDate = 1767312000456;
+      final adapter = _RecordingHttpClientAdapter();
+      final client = MisskeyClient(
+        config: MisskeyClientConfig(
+          baseUrl: Uri.parse('https://misskey.example.com'),
+        ),
+        httpClientAdapter: adapter,
+      );
+      addTearDown(client.dispose);
+
+      await _callAllAdminListMethods(
+        client,
+        sinceDate: sinceDate,
+        untilDate: untilDate,
+      );
+
+      expect(adapter.requests, [
+        for (final path in _adminListPaths)
+          {
+            'path': path,
+            'body': {'sinceDate': sinceDate, 'untilDate': untilDate},
+          },
+      ]);
+    },
+  );
+
+  test('all eight admin list APIs omit absent date cursors', () async {
+    final adapter = _RecordingHttpClientAdapter();
+    final client = MisskeyClient(
+      config: MisskeyClientConfig(
+        baseUrl: Uri.parse('https://misskey.example.com'),
+      ),
+      httpClientAdapter: adapter,
+    );
+    addTearDown(client.dispose);
+
+    await _callAllAdminListMethods(client);
+
+    expect(adapter.requests, [
+      for (final path in _adminListPaths)
+        {'path': path, 'body': <String, dynamic>{}},
+    ]);
+  });
+}
+
+Future<void> _callAllAdminListMethods(
+  MisskeyClient client, {
+  int? sinceDate,
+  int? untilDate,
+}) async {
+  await client.adminAbuseReports.list(
+    sinceDate: sinceDate,
+    untilDate: untilDate,
+  );
+  await client.adminAd.list(sinceDate: sinceDate, untilDate: untilDate);
+  await client.adminAnnouncements.list(
+    sinceDate: sinceDate,
+    untilDate: untilDate,
+  );
+  await client.adminAvatarDecorations.list(
+    sinceDate: sinceDate,
+    untilDate: untilDate,
+  );
+  await client.adminDrive.files(sinceDate: sinceDate, untilDate: untilDate);
+  await client.adminEmoji.list(sinceDate: sinceDate, untilDate: untilDate);
+  await client.adminEmoji.listRemote(
+    sinceDate: sinceDate,
+    untilDate: untilDate,
+  );
+  await client.admin.showModerationLogs(
+    sinceDate: sinceDate,
+    untilDate: untilDate,
+  );
+}
+
+final class _RecordingHttpClientAdapter implements HttpClientAdapter {
+  final List<Map<String, dynamic>> requests = [];
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requests.add({
+      'path': options.uri.path,
+      'body': Map<String, dynamic>.from(options.data as Map<String, dynamic>),
+    });
+    return ResponseBody.fromString(
+      jsonEncode(<dynamic>[]),
+      200,
+      headers: {
+        Headers.contentTypeHeader: ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}

--- a/test/e2e/misskey_admin_p3_e2e_test.dart
+++ b/test/e2e/misskey_admin_p3_e2e_test.dart
@@ -111,6 +111,36 @@ void main() {
       final files = await admin.adminDrive.files(limit: 100, origin: 'local');
       expect(files.map((f) => f.id), contains(uploaded.id));
 
+      final uploadedAt = uploaded.createdAt.millisecondsSinceEpoch;
+      expect(uploaded.userId, isNotNull);
+      final inCreationWindow = await admin.adminDrive.files(
+        limit: 100,
+        userId: uploaded.userId,
+        sinceDate: uploadedAt - const Duration(minutes: 1).inMilliseconds,
+        untilDate: uploadedAt + const Duration(minutes: 1).inMilliseconds,
+      );
+      expect(inCreationWindow.map((file) => file.id), contains(uploaded.id));
+
+      final afterCreationWindow = await admin.adminDrive.files(
+        limit: 100,
+        userId: uploaded.userId,
+        sinceDate: uploadedAt + const Duration(minutes: 1).inMilliseconds,
+      );
+      expect(
+        afterCreationWindow.map((file) => file.id),
+        isNot(contains(uploaded.id)),
+      );
+
+      final beforeCreationWindow = await admin.adminDrive.files(
+        limit: 100,
+        userId: uploaded.userId,
+        untilDate: uploadedAt - const Duration(minutes: 1).inMilliseconds,
+      );
+      expect(
+        beforeCreationWindow.map((file) => file.id),
+        isNot(contains(uploaded.id)),
+      );
+
       final shown = await admin.adminDrive.showFile(fileId: uploaded.id);
       expect(shown['id'], uploaded.id);
       // admin専用のモデレーション向けフィールド

--- a/test/e2e/misskey_admin_p3_e2e_test.dart
+++ b/test/e2e/misskey_admin_p3_e2e_test.dart
@@ -109,13 +109,17 @@ void main() {
       addTearDown(() => alice.drive.files.delete(fileId: uploaded.id));
 
       final files = await admin.adminDrive.files(limit: 100, origin: 'local');
-      expect(files.map((f) => f.id), contains(uploaded.id));
+      final moderationFile = files.singleWhere(
+        (file) => file.id == uploaded.id,
+      );
 
-      final uploadedAt = uploaded.createdAt.millisecondsSinceEpoch;
-      expect(uploaded.userId, isNotNull);
+      // create応答ではuserIdが省略され得るため、Admin一覧のmoderation viewを基準にする。
+      expect(moderationFile.userId, isNotNull);
+      final ownerId = moderationFile.userId!;
+      final uploadedAt = moderationFile.createdAt.millisecondsSinceEpoch;
       final inCreationWindow = await admin.adminDrive.files(
         limit: 100,
-        userId: uploaded.userId,
+        userId: ownerId,
         sinceDate: uploadedAt - const Duration(minutes: 1).inMilliseconds,
         untilDate: uploadedAt + const Duration(minutes: 1).inMilliseconds,
       );
@@ -123,7 +127,7 @@ void main() {
 
       final afterCreationWindow = await admin.adminDrive.files(
         limit: 100,
-        userId: uploaded.userId,
+        userId: ownerId,
         sinceDate: uploadedAt + const Duration(minutes: 1).inMilliseconds,
       );
       expect(
@@ -133,7 +137,7 @@ void main() {
 
       final beforeCreationWindow = await admin.adminDrive.files(
         limit: 100,
-        userId: uploaded.userId,
+        userId: ownerId,
         untilDate: uploadedAt - const Duration(minutes: 1).inMilliseconds,
       );
       expect(


### PR DESCRIPTION
## 概要

Admin一覧系8 APIに sinceDate / untilDate（Unix時刻ミリ秒）を追加します。nullは送信せず、既存呼び出しとの互換性を維持します。

- abuse reports / ads / announcements / avatar decorations
- drive files / local emojis / remote emojis / moderation logs
- adapterテストで8 APIの転送値とnull非送信を固定
- Drive E2EでsinceDate下限とuntilDate上限を検証

## 上流制約

avatar decorationsは公式schemaが引数を受理しますが、現行upstream handlerはページネーション引数を無視します。公開APIとdartdocには、forkおよび将来互換向けであることを明記しています。

## 検証

- fvm dart analyze
- fvm dart test --exclude-tags e2e: 573 passed
- マージ判断の再現可能な根拠はCI・adapter/単体テスト。ローカルDocker E2Eはmaintainer-onlyの補助検証として別コメントに記録
- build_runner: 生成差分なし
- git diff --check
- 独立サブエージェントレビュー: approve

Closes #24