### PR TITLE
docs: remove private package references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Documented migration from the unpublished `misskey_api_kit` predecessor and the local-only `misskey_drive` package in all six READMEs (issue #31)
+- Documented migration from the unpublished `misskey_api_kit` predecessor in all six READMEs (issue #31)
 - Redacted authentication tokens and account-lifecycle credentials from HTTP debug request logs without modifying transmitted request bodies (issue #11)
 - **Breaking:** Replaced dynamic policy maps with `MisskeyRolePolicies` on effective-policy responses and with typed `MisskeyRolePolicyOverride` entries on role definitions (issue #10)
 - Added the explicit `MetaApi.hasMetaKey()` name for metadata key-presence checks and deprecated the ambiguous `supports()` alias; key presence does not interpret a boolean metadata value or indicate endpoint availability (issue #41)

--- a/README.de.md
+++ b/README.de.md
@@ -229,12 +229,11 @@ final client = MisskeyClient(
 | `Logger` / `FunctionLogger` | Klassen mit denselben Namen |
 | `kReleaseMode` / `kDebugMode` | Nicht Teil der öffentlichen API; siehe unten |
 
-### Migration von misskey_api_kit und misskey_drive
+### Migration von misskey_api_kit
 
-`misskey_api_kit` war ein unveröffentlichter Vorgänger, und `misskey_drive` war ein ausschließlich lokal verwendetes Paket. Entfernen Sie diese Abhängigkeiten und erstellen Sie einen einzigen `MisskeyClient`, anstatt separate Instanzen von `MisskeyApiKitClient` und `MisskeyDriveClient` zu verwenden.
+`misskey_api_kit` war ein unveröffentlichter Vorgänger. Entfernen Sie diese Abhängigkeit und verwenden Sie einen einzigen `MisskeyClient` anstelle einer separaten `MisskeyApiKitClient`-Instanz.
 
 - Ersetzen Sie die Einstiegspunkte `account`, `notes`, `notifications`, `channels` und `users` von `MisskeyApiKitClient` durch die gleichnamigen Eigenschaften von `MisskeyClient`.
-- Ersetzen Sie `MisskeyDriveClient.files`, `.folders` und `.stats` durch `client.drive.files`, `client.drive.folders` und `client.drive.stats`.
 
 Dies ist kein direkter Ersatz: Einige Methoden wurden umbenannt, und viele Antworten, die zuvor untypisierte `Map<String, dynamic>`-Werte waren, verwenden jetzt typisierte Modelle, während einige APIs weiterhin untypisierte Maps zurückgeben. Migrieren Sie jeden Aufruf anhand der [API-Referenz](https://librarylibrarian.github.io/misskey_client/).
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -229,12 +229,11 @@ final client = MisskeyClient(
 | `Logger` / `FunctionLogger` | Classes portant les mêmes noms |
 | `kReleaseMode` / `kDebugMode` | Non inclus dans l'API publique ; voir ci-dessous |
 
-### Migration depuis misskey_api_kit et misskey_drive
+### Migration depuis misskey_api_kit
 
-`misskey_api_kit` était un prédécesseur non publié, et `misskey_drive` était un package réservé à un usage local. Supprimez ces dépendances et créez un seul `MisskeyClient` au lieu d'instances distinctes de `MisskeyApiKitClient` et `MisskeyDriveClient`.
+`misskey_api_kit` était un prédécesseur non publié. Supprimez cette dépendance et utilisez un seul `MisskeyClient` au lieu d'une instance distincte de `MisskeyApiKitClient`.
 
 - Remplacez les points d'entrée `account`, `notes`, `notifications`, `channels` et `users` de `MisskeyApiKitClient` par les propriétés de même nom de `MisskeyClient`.
-- Remplacez `MisskeyDriveClient.files`, `.folders` et `.stats` par `client.drive.files`, `client.drive.folders` et `client.drive.stats`.
 
 Il ne s'agit pas d'un remplacement direct : certaines méthodes ont été renommées, et de nombreuses réponses qui étaient auparavant des valeurs `Map<String, dynamic>` brutes utilisent maintenant des modèles typés, tandis que certaines API renvoient toujours des maps brutes. Migrez chaque appel en vous reportant à la [référence de l'API](https://librarylibrarian.github.io/misskey_client/).
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -228,12 +228,11 @@ final client = MisskeyClient(
 | `Logger` / `FunctionLogger` | 同名クラス |
 | `kReleaseMode` / `kDebugMode` | 公開 API に含めない（下記参照） |
 
-### misskey_api_kit と misskey_drive からの移行
+### misskey_api_kit からの移行
 
-`misskey_api_kit` はパッケージレジストリに公開されていない前身パッケージ、`misskey_drive` はローカル専用パッケージでした。これらの依存関係を削除し、`MisskeyApiKitClient` と `MisskeyDriveClient` を個別に作成する代わりに、単一の `MisskeyClient` を作成してください。
+`misskey_api_kit` はパッケージレジストリに公開されていない前身パッケージです。この依存関係を削除し、個別の `MisskeyApiKitClient` の代わりに単一の `MisskeyClient` を使用してください。
 
 - `MisskeyApiKitClient` の `account`、`notes`、`notifications`、`channels`、`users` の各エントリーポイントは、`MisskeyClient` の同名プロパティに置き換えます。
-- `MisskeyDriveClient.files`、`.folders`、`.stats` は、`client.drive.files`、`client.drive.folders`、`client.drive.stats` に置き換えます。
 
 これはそのまま置き換えられる互換 API ではありません。一部のメソッド名は変更され、以前は raw の `Map<String, dynamic>` だったレスポンスの多くは型付きモデルになっていますが、raw map を返す API も残っています。[API リファレンス](https://librarylibrarian.github.io/misskey_client/)を参照し、呼び出し単位で移行してください。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -229,12 +229,11 @@ final client = MisskeyClient(
 | `Logger` / `FunctionLogger` | 이름이 같은 클래스 |
 | `kReleaseMode` / `kDebugMode` | 공개 API에 포함하지 않음(아래 참조) |
 
-### misskey_api_kit 및 misskey_drive에서 마이그레이션
+### misskey_api_kit에서 마이그레이션
 
-`misskey_api_kit`는 배포되지 않은 이전 패키지이고, `misskey_drive`는 로컬 전용 패키지였습니다. 해당 의존성을 제거하고 `MisskeyApiKitClient`와 `MisskeyDriveClient` 인스턴스를 따로 만드는 대신 하나의 `MisskeyClient`를 생성하세요.
+`misskey_api_kit`는 배포되지 않은 이전 패키지입니다. 해당 의존성을 제거하고 별도의 `MisskeyApiKitClient` 인스턴스 대신 하나의 `MisskeyClient`를 사용하세요.
 
 - `MisskeyApiKitClient`의 `account`, `notes`, `notifications`, `channels`, `users` 진입점을 `MisskeyClient`의 같은 이름을 가진 속성으로 교체하세요.
-- `MisskeyDriveClient.files`, `.folders`, `.stats`를 `client.drive.files`, `client.drive.folders`, `client.drive.stats`로 교체하세요.
 
 이는 그대로 교체할 수 있는 호환 API가 아닙니다. 일부 메서드 이름이 변경되었고 이전에 원시 `Map<String, dynamic>` 값이었던 많은 응답은 이제 타입 지정 모델을 사용하지만, 여전히 원시 map을 반환하는 API도 있습니다. [API 참조](https://librarylibrarian.github.io/misskey_client/)를 확인하여 각 호출을 마이그레이션하세요.
 

--- a/README.md
+++ b/README.md
@@ -229,12 +229,11 @@ final client = MisskeyClient(
 | `Logger` / `FunctionLogger` | Classes with the same names |
 | `kReleaseMode` / `kDebugMode` | Not part of the public API; see below |
 
-### Migrating from misskey_api_kit and misskey_drive
+### Migrating from misskey_api_kit
 
-`misskey_api_kit` was an unpublished predecessor, and `misskey_drive` was a local-only package. Remove those dependencies and create a single `MisskeyClient` instead of separate `MisskeyApiKitClient` and `MisskeyDriveClient` instances.
+`misskey_api_kit` was an unpublished predecessor. Remove that dependency and use a single `MisskeyClient` instead of a separate `MisskeyApiKitClient` instance.
 
 - Replace the `account`, `notes`, `notifications`, `channels`, and `users` entry points from `MisskeyApiKitClient` with the properties of the same names on `MisskeyClient`.
-- Replace `MisskeyDriveClient.files`, `.folders`, and `.stats` with `client.drive.files`, `client.drive.folders`, and `client.drive.stats`.
 
 This is not a drop-in replacement: some methods have been renamed, and many responses that were raw `Map<String, dynamic>` values now use typed models, although some APIs still return raw maps. Migrate each call against the [API reference](https://librarylibrarian.github.io/misskey_client/).
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -229,12 +229,11 @@ final client = MisskeyClient(
 | `Logger` / `FunctionLogger` | 同名类 |
 | `kReleaseMode` / `kDebugMode` | 不属于公共 API；详见下文 |
 
-### 从 misskey_api_kit 和 misskey_drive 迁移
+### 从 misskey_api_kit 迁移
 
-`misskey_api_kit` 是未发布的前身包，`misskey_drive` 是仅供本地使用的包。请移除这些依赖，并创建一个 `MisskeyClient`，而不是分别创建 `MisskeyApiKitClient` 和 `MisskeyDriveClient`。
+`misskey_api_kit` 是未发布的前身包。请移除该依赖，并使用一个 `MisskeyClient`，而不是单独创建 `MisskeyApiKitClient`。
 
 - 将 `MisskeyApiKitClient` 的 `account`、`notes`、`notifications`、`channels` 和 `users` 入口替换为 `MisskeyClient` 上的同名属性。
-- 将 `MisskeyDriveClient.files`、`.folders` 和 `.stats` 替换为 `client.drive.files`、`client.drive.folders` 和 `client.drive.stats`。
 
 这并非可直接替换的兼容 API：部分方法已重命名，许多原先以原始 `Map<String, dynamic>` 返回的响应现在使用类型化模型，但仍有一些 API 返回原始 map。请对照 [API 参考](https://librarylibrarian.github.io/misskey_client/)逐个迁移调用。
 


### PR DESCRIPTION
## 概要

公開されていないローカル専用パッケージに関する記述を、公開ドキュメントから削除します。

## 変更内容

- README 全6言語から対象パッケージ固有の移行案内を削除
- CHANGELOG の移行ガイド記述を公開対象の内容に修正
- `misskey_api_kit` からの移行案内は維持

Issue #31 と PR #70 の本文および編集履歴についても、対象記述の削除を別途実施済みです。

## 検証

- `fvm dart analyze`: No issues found
- `fvm dart test --exclude-tags e2e`: 639 passed
- `git diff --check`
- 対象文字列の残存確認: 0件

Refs #31